### PR TITLE
Added support for method overloading for YarnCommands

### DIFF
--- a/Unity/Assets/Yarn Spinner/Code/DialogueRunner.cs
+++ b/Unity/Assets/Yarn Spinner/Code/DialogueRunner.cs
@@ -318,6 +318,7 @@ namespace Yarn.Unity
 				return false;
 
 			int numberOfMethodsFound = 0;
+			List<string[]> errorValues = new List<string[]>();
 
 			List<string> parameters;
 
@@ -342,36 +343,61 @@ namespace Yarn.Unity
 					foreach (var attribute in attributes) {
 						if (attribute.commandString == commandName) {
 
-							// Verify that this method has the right number of parameters
+							
 							var methodParameters = method.GetParameters();
-
-							if (methodParameters.Length != parameters.Count) {
-								Debug.LogErrorFormat(sceneObject, "Method \"{0}\" wants to respond to Yarn command \"{1}\", but it has a different number of parameters ({2}) to those provided ({3})!", method.Name, commandName, methodParameters.Length, parameters.Count);
-								return false;
+							bool paramsMatch = false;
+							// Check if this is a params array
+							if (methodParameters.Length == 1 && methodParameters[0].ParameterType.IsAssignableFrom(typeof(string[])))
+								{
+									// Cool, we can send the command!
+									string[][] paramWrapper = new string[1][];
+									paramWrapper[0] = parameters.ToArray();
+                                    method.Invoke(component, paramWrapper);
+									numberOfMethodsFound++;
+									paramsMatch = true;
+								
 							}
-
-							// Verify that this method has only string parameters (or no parameters)
-							foreach (var paramInfo in methodParameters) {
-								if (paramInfo.ParameterType.IsAssignableFrom(typeof(string)) == false) {
-									Debug.LogErrorFormat(sceneObject, "Method \"{0}\" wants to respond to Yarn command \"{1}\", but not all of its parameters are strings!", method.Name, commandName);
-									return false;
+							// Otherwise, verify that this method has the right number of parameters
+							else if (methodParameters.Length == parameters.Count)
+							{
+								paramsMatch = true;
+								foreach (var paramInfo in methodParameters)
+								{
+									if (!paramInfo.ParameterType.IsAssignableFrom(typeof(string)))
+									{
+										Debug.LogErrorFormat(sceneObject, "Method \"{0}\" wants to respond to Yarn command \"{1}\", but not all of its parameters are strings!", method.Name, commandName);
+										paramsMatch = false;
+										break;
+									}
+								}
+								if (paramsMatch)
+								{
+									// Cool, we can send the command!
+									method.Invoke(component, parameters.ToArray());
+									numberOfMethodsFound++;
 								}
 							}
-
-							// Cool, we can send the command!
-							method.Invoke(component, parameters.ToArray());
-							numberOfMethodsFound ++;
-
+							//parameters are invalid, but name matches.
+							if (!paramsMatch)
+							{
+								//save this error in case a matching command is never found.
+								errorValues.Add(new string[] { method.Name, commandName, methodParameters.Length.ToString(), parameters.Count.ToString() });
+							}
 						}
 					}
-				} 
+				}
 			}
 
 			// Warn if we found multiple things that could respond
 			// to this command.
 			if (numberOfMethodsFound > 1) {
 				Debug.LogWarningFormat(sceneObject, "The command \"{0}\" found {1} targets. " +
-					"You should only have one - check your scripts.");
+					"You should only have one - check your scripts.", command, numberOfMethodsFound);
+			} else if (numberOfMethodsFound == 0) {
+				//list all of the near-miss methods only if a proper match is not found, but correctly-named methods are.
+				foreach (string[] errorVal in errorValues) {
+					Debug.LogErrorFormat(sceneObject, "Method \"{0}\" wants to respond to Yarn command \"{1}\", but it has a different number of parameters ({2}) to those provided ({3}), or is not a string array!", errorVal[0], errorVal[1], errorVal[2], errorVal[3]);
+				}
 			}
 
 			return numberOfMethodsFound > 0;

--- a/Unity/Assets/Yarn Spinner/Code/DialogueRunner.cs
+++ b/Unity/Assets/Yarn Spinner/Code/DialogueRunner.cs
@@ -352,7 +352,7 @@ namespace Yarn.Unity
 									// Cool, we can send the command!
 									string[][] paramWrapper = new string[1][];
 									paramWrapper[0] = parameters.ToArray();
-                                    method.Invoke(component, paramWrapper);
+									method.Invoke(component, paramWrapper);
 									numberOfMethodsFound++;
 									paramsMatch = true;
 								


### PR DESCRIPTION
This change allows multiple functions to share the same YarnCommand tag, but differ in their parameters list. Based on the number of arguments provided, the correct one will be chosen and used without throwing an error. For example, from my own game:

    [YarnCommand("hop")]
    public void Hop()
    {
        HopMulti("1");
    }
    
    [YarnCommand("hop")]
    public void HopMulti(string times)
    {
        Animations.Add("Hop", new Hop(this, int.Parse(times)));
    }
This allows my writer to call <<hop Becky>> or <<hop Becky 4>> without needing to remember another command name or to add an extraneous '1' to the hop command. If no proper matching function is found, or if too many matches are found, errors will still be logged as before. 
Also added, because it is a common method of overloading for an arbitrary number of parameters, is support for params arrays. These allow you to define functions like this:
`public static int Min(params int[] args)`
and call them like this:
`lowest = Min(a,b,c,d);`
without the need for a `new int[]{...}` to be put in place. For Yarn's purposes, a command that takes a `params string[]` will be assumed to be able to handle an arbitrary number of arguments, so something like <<ThrowSnowballs Becky kid1 kid2 Jason JasonsBrother>> will be valid no matter how many targets fall to Becky's wrath today. As a bonus, the `params` tag need not be present, but its existence informed the design decision.

I took care to follow established style conventions (tabs, curly bracket on new line), but I struggled with my editor to pull this off, and I may have missed something.

This is an edit straight to Unity/Assets/YS/Code, where the source matched the files I could see and change inside Unity. If this feature needs to be mirrored elsewhere in the source to be functional, point me to it and I'll start digging.

This feature not being present in the first place was, I'm certain, intentional - this is the latest in a very long string of very messy hacked versions of this function, and I'm sure half of the solutions and problems I found came up during the original development, when it was decided to keep it simple rather than broken. However, I'm finally satisfied with this design, which I think is reasonably elegant, readable enough (not perfect, but it could be *much* worse), and powerful enough to be worth including.

Oh, also, there was an existing error in the Debug Warning on line 374/295 that I fixed. :) Also, I noticed that this repository uses Git Flow extensively - I thoroughly support this move, and I can create an explicit Merge commit from my feature branch if that would be appreciated.