### PR TITLE
WIP - crude first pass at node #return functionality

### DIFF
--- a/YarnSpinner/Compiler.cs
+++ b/YarnSpinner/Compiler.cs
@@ -84,7 +84,7 @@ namespace Yarn
 
                 // If this compiled node has no lingering options to show at the end of the node,
                 // AND it isn't a special returnable node then stop at the end.
-                if (hasRemainingOptions == false && isReturnable == false )
+                if (hasRemainingOptions == false && !isReturnable)
                 {
                     Emit(compiledNode, ByteCode.Stop);
                 }

--- a/YarnSpinner/Program.cs
+++ b/YarnSpinner/Program.cs
@@ -395,7 +395,8 @@ namespace Yarn
 		/// stops execution
 		Stop,
 		/// run the node whose name is at the top of the stack
-		RunNode
-
+		RunNode,
+		/// run the node whose name is at the top of the stack but come back again
+		RunNodeAndReturn
 	}
 }

--- a/YarnSpinner/VirtualMachine.cs
+++ b/YarnSpinner/VirtualMachine.cs
@@ -357,7 +357,11 @@ namespace Yarn
                 {
                     _returnStates.Add(state);
                 }
-                nodeCompleteHandler (new Dialogue.NodeCompleteResult (nodeName));
+                else
+                {
+                    nodeCompleteHandler (new Dialogue.NodeCompleteResult (nodeName));    
+                }
+                
                 SetNode (nodeName);
                 break;
             case ByteCode.AddOption:


### PR DESCRIPTION
Re: https://github.com/thesecretlab/YarnSpinner/issues/92
This works in my limited test case used so far, but I expect a) many edge cases and b) I've probably missed something really obvious that someone who understands this project should cast an eye over.

I've not begun testing with variables, to see what happens on state replay,  but vaguely functional flow control at least. PR being created for comment from the YS guys who can hopefully advise if I'm going in the wrong direction or not.

```
title: Start
tags: tag1
colorID: 0
position: 0,0
---
Start: This is a line in start block. #line:a76b29
Start: This is too, in the start block. #line:7b5c3c
[[JumpReturn1]] #return
Start: And we're back in start block, at the line after the jump! #line:0c8b0c
[[JumpReturn2]] #return
Start: And we're back in start block, and next we'll test menus;
->Go and come back?
    [[QuickChoiceReturn]] #return
-> Or stay in this block?
    We stayed put...
And now the game is going to end with a normal end of block jump.
[[End]]
===
title: JumpReturn1
tags: tag2
colorID: 0
position: 0,0
---
JumpReturn1: Line 3 is froma jump, and we're now in a new block. #line:4d4894
JumpReturn1: Line 4 is the next line in the new block. #line:b26d94
===
title: JumpReturn2
tags: tag3
colorID: 0
position: 0,0
---
JumpReturn2: Line 5 is jumping back into jumpblock 2! #line:7daa33
JumpReturn2: Line 6 is also in jumpblock 2. #line:88a7f3
===
title: End
tags: tag4
colorID: 0
position: 0,0
---
End: We ran out of calls and went to the End block. Game over! #line:a2e4d5
===
title: QuickChoiceReturn
---
We jumped in a menu!
===
```

Results in expected output:

```
YarnSpinnerConsole.exe run ../../test.yarn.txt
Start: This is a line in start block.
Start: This is too, in the start block.
JumpReturn1: Line 3 is froma jump, and we're now in a new block.
JumpReturn1: Line 4 is the next line in the new block.
Start: And we're back in start block, at the line after the jump!
JumpReturn2: Line 5 is jumping back into jumpblock 2!
JumpReturn2: Line 6 is also in jumpblock 2.
Start: And we're back in start block, and next we'll test menus;
Options:
1. Go and come back?
2.  Or stay in this block?
? 1
We jumped in a menu!
And now the game is going to end with a normal end of block jump.
End: We ran out of calls and went to the End block. Game over!
```
or selecting 2 for our choice winds up continueing on as expected.