### PR TITLE
Added option to dump parse tree to JSON

### DIFF
--- a/YarnSpinner/Dialogue.cs
+++ b/YarnSpinner/Dialogue.cs
@@ -157,9 +157,11 @@ namespace Yarn {
 		// The collection of nodes that we've seen.
 		private HashSet<String> visitedNodeNames = new HashSet<string>();
 
-		public Dialogue(Yarn.VariableStorage continuity) {
+		public Dialogue(Yarn.VariableStorage continuity, Logger debugLogger, Logger errorLogger) {
+			LogDebugMessage = debugLogger;
+			LogErrorMessage = errorLogger;
 			this.continuity = continuity;
-			loader = new Loader (this);
+			loader = new Loader (LogDebugMessage, LogErrorMessage);
 			library = new Library ();
 
 			library.ImportLibrary (new StandardLibrary ());

--- a/YarnSpinner/Dialogue.cs
+++ b/YarnSpinner/Dialogue.cs
@@ -27,6 +27,9 @@ SOFTWARE.
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Newtonsoft.Json;
 
 namespace Yarn {
 
@@ -208,11 +211,17 @@ namespace Yarn {
 
 
 			if (showJson) {
+			    var sb = new StringBuilder();
+			    var sw = new StringWriter(sb);
+			    using(var jw = new JsonTextWriter(sw)) {
+				jw.Formatting = Formatting.Indented;
+				jw.WriteStartArray();
 				foreach(var kvp in nodes) {
-					// this is a litlte untidy because PrintParseTree() no longer
-					// needs to be part of Loader
-					Console.WriteLine(kvp.Value.ToJson());
+				    kvp.Value.ToJson(jw);
 				}
+				jw.WriteEnd();
+			    }
+			    Console.WriteLine(sb.ToString());
 			}
 
 			program = loader.Load(nodes, fileName, program);

--- a/YarnSpinner/Dialogue.cs
+++ b/YarnSpinner/Dialogue.cs
@@ -176,16 +176,16 @@ namespace Yarn {
 		}
 
 		// Load a file from disk.
-		public void LoadFile(string fileName, bool showTokens = false, bool showParseTree = false, string onlyConsiderNode=null) {
+		public void LoadFile(string fileName, bool showTokens = false, bool showParseTree = false, bool showJson = false, string onlyConsiderNode=null) {
 			System.IO.StreamReader reader = new System.IO.StreamReader(fileName);
 			string inputString = reader.ReadToEnd ();
 			reader.Close ();
 
-			LoadString (inputString, fileName, showTokens, showParseTree, onlyConsiderNode);
+			LoadString (inputString, fileName, showTokens, showParseTree, showJson, onlyConsiderNode);
 		}
 
 		// Ask the loader to parse a string. Returns the number of nodes that were loaded.
-		public void LoadString(string text, string fileName="<input>", bool showTokens=false, bool showParseTree=false, string onlyConsiderNode=null) {
+		public void LoadString(string text, string fileName="<input>", bool showTokens=false, bool showParseTree=false, bool showJson=false, string onlyConsiderNode=null) {
 
 			if (LogDebugMessage == null) {
 				throw new YarnException ("LogDebugMessage must be set before loading");
@@ -203,6 +203,15 @@ namespace Yarn {
 					// this is a litlte untidy because PrintParseTree() no longer
 					// needs to be part of Loader
 					loader.PrintParseTree(kvp.Value);
+				}
+			}
+
+
+			if (showJson) {
+				foreach(var kvp in nodes) {
+					// this is a litlte untidy because PrintParseTree() no longer
+					// needs to be part of Loader
+					Console.WriteLine(kvp.Value.ToJson());
 				}
 			}
 

--- a/YarnSpinner/Dialogue.cs
+++ b/YarnSpinner/Dialogue.cs
@@ -195,7 +195,18 @@ namespace Yarn {
 				throw new YarnException ("LogErrorMessage must be set before loading");
 			}
 
-			program = loader.Load(text, library, fileName, program, showTokens, showParseTree, onlyConsiderNode);
+			var nodes = loader.Parse(text, library, fileName, program, showTokens, onlyConsiderNode);
+
+
+			if (showParseTree) {
+				foreach(var kvp in nodes) {
+					// this is a litlte untidy because PrintParseTree() no longer
+					// needs to be part of Loader
+					loader.PrintParseTree(kvp.Value);
+				}
+			}
+
+			program = loader.Load(nodes, fileName, program);
 		}
 
 		private VirtualMachine vm;

--- a/YarnSpinner/Dialogue.cs
+++ b/YarnSpinner/Dialogue.cs
@@ -180,7 +180,6 @@ namespace Yarn {
 			reader.Close ();
 
 			LoadString (inputString, fileName, showTokens, showParseTree, onlyConsiderNode);
-
 		}
 
 		// Ask the loader to parse a string. Returns the number of nodes that were loaded.
@@ -195,7 +194,6 @@ namespace Yarn {
 			}
 
 			program = loader.Load(text, library, fileName, program, showTokens, showParseTree, onlyConsiderNode);
-
 		}
 
 		private VirtualMachine vm;

--- a/YarnSpinner/Loader.cs
+++ b/YarnSpinner/Loader.cs
@@ -36,7 +36,8 @@ namespace Yarn {
 
 	internal class Loader {
 
-		private Dialogue dialogue;
+		Logger LogDebugMessage;
+		Logger LogErrorMessage;
 
 		public Program program { get; private set; }
 
@@ -49,24 +50,25 @@ namespace Yarn {
 			}
 
 			// Let's see what we got
-			dialogue.LogDebugMessage("Tokens:");
-			dialogue.LogDebugMessage(sb.ToString());
+			LogDebugMessage("Tokens:");
+			LogDebugMessage(sb.ToString());
 
 		}
 
 		// Prints the parse tree for the node
 		void PrintParseTree(Yarn.Parser.ParseNode rootNode) {
-			dialogue.LogDebugMessage("Parse Tree:");
-			dialogue.LogDebugMessage(rootNode.PrintTree(0));
+			LogDebugMessage("Parse Tree:");
+			LogDebugMessage(rootNode.PrintTree(0));
 
 		}
 
 		// Prepares a loader. 'implementation' is used for logging.
-		public Loader(Dialogue dialogue) {
-			if (dialogue == null)
-				throw new ArgumentNullException ("dialogue");
+		public Loader(Logger logDebug, Logger logError) {
+			if (logDebug == null || logError == null)
+				throw new ArgumentNullException ("logDebug or logError");
 			
-			this.dialogue = dialogue;
+			this.LogDebugMessage = logDebug;
+			this.LogErrorMessage = logDebug;
 
 		}
 
@@ -206,10 +208,10 @@ namespace Yarn {
 					}
 
 				} catch (InvalidCastException) {
-					dialogue.LogErrorMessage ("Error parsing Yarn input: it's valid JSON, but " +
+					LogErrorMessage ("Error parsing Yarn input: it's valid JSON, but " +
 						"it didn't match the data layout I was expecting.");
 				} catch (InvalidJsonException e) {
-					dialogue.LogErrorMessage ("Error parsing Yarn input: " + e.Message);
+					LogErrorMessage ("Error parsing Yarn input: " + e.Message);
 				}
 			}
 

--- a/YarnSpinner/Loader.cs
+++ b/YarnSpinner/Loader.cs
@@ -56,13 +56,12 @@ namespace Yarn {
 		}
 
 		// Prints the parse tree for the node
-		void PrintParseTree(Yarn.Parser.ParseNode rootNode) {
+		public void PrintParseTree(Yarn.Parser.ParseNode rootNode) {
 			LogDebugMessage("Parse Tree:");
 			LogDebugMessage(rootNode.PrintTree(0));
-
 		}
 
-		// Prepares a loader. 'implementation' is used for logging.
+		// Prepares a loader, using the given callbacks for logging.
 		public Loader(Logger logDebug, Logger logError) {
 			if (logDebug == null || logError == null)
 				throw new ArgumentNullException ("logDebug or logError");
@@ -72,7 +71,7 @@ namespace Yarn {
 
 		}
 
-		public Dictionary<string, Yarn.Parser.Node> Parse(string text, Library library, string fileName, Program includeProgram, bool showTokens, bool showParseTree, string onlyConsiderNode) {
+		public Dictionary<string, Yarn.Parser.Node> Parse(string text, Library library, string fileName, Program includeProgram, bool showTokens, string onlyConsiderNode) {
 // The final parsed nodes that were in the file we were given
 			Dictionary<string, Yarn.Parser.Node> nodes = new Dictionary<string, Parser.Node>();
 
@@ -112,9 +111,6 @@ namespace Yarn {
 
 					node.name = nodeInfo.title;
 
-					if (showParseTree)
-						PrintParseTree(node);
-
 					nodes[nodeInfo.title] = node;
 
 					nodesLoaded++;
@@ -136,15 +132,12 @@ namespace Yarn {
 			return nodes;
 		}
 
-		// Given a bunch of raw text, load all nodes that were inside it.
+
+		// Given a set of parsed nodes, compile and load all nodes that were inside it.
 		// You can call this multiple times to append to the collection of nodes,
 		// but note that new nodes will replace older ones with the same name.
 		// Returns the number of nodes that were loaded.
-		public Program Load(string text, Library library, string fileName, Program includeProgram, bool showTokens, bool showParseTree, string onlyConsiderNode) {
-
-			var nodes = this.Parse(text, library, fileName, includeProgram, showTokens, showParseTree, onlyConsiderNode);
-			Console.WriteLine("Dumping nodes, presumably");
-
+		public Program Load(Dictionary<string, Yarn.Parser.Node> nodes, string fileName, Program includeProgram) {
 			var compiler = new Yarn.Compiler(fileName);
 
 			foreach (var node in nodes) {
@@ -156,6 +149,15 @@ namespace Yarn {
 			}
 
 			return compiler.program;
+		}
+
+
+		// Given a bunch of raw text, parse it, then load all the nodes with
+		// Load()
+		public Program LoadString(string text, Library library, string fileName, Program includeProgram, bool showTokens, string onlyConsiderNode) {
+
+			var nodes = this.Parse(text, library, fileName, includeProgram, showTokens, onlyConsiderNode);
+			return this.Load(nodes, fileName, includeProgram);
 		}
 
 		// The raw text of the Yarn node, plus metadata

--- a/YarnSpinner/Loader.cs
+++ b/YarnSpinner/Loader.cs
@@ -70,13 +70,8 @@ namespace Yarn {
 
 		}
 
-		// Given a bunch of raw text, load all nodes that were inside it.
-		// You can call this multiple times to append to the collection of nodes,
-		// but note that new nodes will replace older ones with the same name.
-		// Returns the number of nodes that were loaded.
-		public Program Load(string text, Library library, string fileName, Program includeProgram, bool showTokens, bool showParseTree, string onlyConsiderNode) {
-
-			// The final parsed nodes that were in the file we were given
+		public Dictionary<string, Yarn.Parser.Node> Parse(string text, Library library, string fileName, Program includeProgram, bool showTokens, bool showParseTree, string onlyConsiderNode) {
+// The final parsed nodes that were in the file we were given
 			Dictionary<string, Yarn.Parser.Node> nodes = new Dictionary<string, Parser.Node>();
 
 			// Load the raw data and get the array of node title-text pairs
@@ -135,9 +130,18 @@ namespace Yarn {
 					throw new InvalidOperationException (message);
 				}
 				#endif 
-
-
 			}
+			return nodes;
+		}
+
+		// Given a bunch of raw text, load all nodes that were inside it.
+		// You can call this multiple times to append to the collection of nodes,
+		// but note that new nodes will replace older ones with the same name.
+		// Returns the number of nodes that were loaded.
+		public Program Load(string text, Library library, string fileName, Program includeProgram, bool showTokens, bool showParseTree, string onlyConsiderNode) {
+
+			var nodes = this.Parse(text, library, fileName, includeProgram, showTokens, showParseTree, onlyConsiderNode);
+			Console.WriteLine("Dumping nodes, presumably");
 
 			var compiler = new Yarn.Compiler(fileName);
 
@@ -150,7 +154,6 @@ namespace Yarn {
 			}
 
 			return compiler.program;
-
 		}
 
 		// The raw text of the Yarn node, plus metadata

--- a/YarnSpinner/Parser.cs
+++ b/YarnSpinner/Parser.cs
@@ -170,7 +170,14 @@ namespace Yarn {
 
 			internal override string ToJson(int indentLevel=0) {
 				var sb = new StringBuilder();
-				sb.Append("Placeholder");
+				sb.Append("{type: \"Node\"; contents: [");
+				foreach(var statement in _statements) {
+					sb.Append(statement.ToJson(indentLevel+1));
+					// BUGGO: Trailing commas are theoretically 
+					// not allowed in json.
+					sb.Append(", ");
+				}
+				sb.Append("]}");
 				return sb.ToString();
 			}
 
@@ -265,9 +272,25 @@ namespace Yarn {
 			}
 
 			internal override string ToJson(int indentLevel=0) {
-				var sb = new StringBuilder();
-				sb.Append("Placeholder");
-				return sb.ToString();
+				
+				switch (type) {
+				case Type.Block:
+					return block.ToJson (indentLevel);
+				case Type.IfStatement:
+					return ifStatement.ToJson (indentLevel);
+				case Type.OptionStatement:
+					return optionStatement.ToJson (indentLevel);
+				case Type.AssignmentStatement:
+					return assignmentStatement.ToJson (indentLevel);
+				case Type.ShortcutOptionGroup:
+					return shortcutOptionGroup.ToJson (indentLevel);
+				case Type.CustomCommand:
+					return customCommand.ToJson (indentLevel);
+				case Type.Line:
+					return "{type: \"Line\", contents: \"" + line + "\"}";
+				}
+
+				throw new ArgumentNullException ();
 			}
 		}
 
@@ -338,9 +361,13 @@ namespace Yarn {
 			}
 
 			internal override string ToJson(int indentLevel=0) {
-				var sb = new StringBuilder();
-				sb.Append("Placeholder");
-				return sb.ToString();
+				switch (type) {
+				case Type.Expression:
+					return expression.ToJson (indentLevel + 1);
+				case Type.ClientCommand:
+					return "{type: \"Command\", contents: \"" + clientCommand + "\"}";
+				}
+				return "";
 			}
 		}
 
@@ -384,7 +411,7 @@ namespace Yarn {
 
 			internal override string ToJson(int indentLevel=0) {
 				var sb = new StringBuilder();
-				sb.Append("Placeholder");
+				sb.Append("ShortcutGroupPlaceholder");
 				return sb.ToString();
 			}
 		}
@@ -439,7 +466,7 @@ namespace Yarn {
 
 			internal override string ToJson(int indentLevel=0) {
 				var sb = new StringBuilder();
-				sb.Append("Placeholder");
+				sb.Append("ShortcutOptionPlaceholder");
 				return sb.ToString();
 			}
 		}
@@ -489,7 +516,7 @@ namespace Yarn {
 
 			internal override string ToJson(int indentLevel=0) {
 				var sb = new StringBuilder();
-				sb.Append("Placeholder");
+				sb.Append("PBlocklaceholder");
 				return sb.ToString();
 			}
 		}
@@ -554,7 +581,7 @@ namespace Yarn {
 
 			internal override string ToJson(int indentLevel=0) {
 				var sb = new StringBuilder();
-				sb.Append("Placeholder");
+				sb.Append("OptionPlaceholder");
 				return sb.ToString();
 			}
 		}
@@ -699,7 +726,7 @@ namespace Yarn {
 
 			internal override string ToJson(int indentLevel=0) {
 				var sb = new StringBuilder();
-				sb.Append("Placeholder");
+				sb.Append("IfPlaceholder");
 				return sb.ToString();
 			}
 		}
@@ -777,7 +804,7 @@ namespace Yarn {
 
 			internal override string ToJson(int indentLevel=0) {
 				var sb = new StringBuilder();
-				sb.Append("Placeholder");
+				sb.Append("ValuePlaceholder");
 				return sb.ToString();
 			}
 		}
@@ -1128,7 +1155,7 @@ namespace Yarn {
 
 			internal override string ToJson(int indentLevel=0) {
 				var sb = new StringBuilder();
-				sb.Append("Placeholder");
+				sb.Append("ExpressionPlaceholder");
 				return sb.ToString();
 			}
 		}
@@ -1179,7 +1206,14 @@ namespace Yarn {
 
 			internal override string ToJson(int indentLevel=0) {
 				var sb = new StringBuilder();
-				sb.Append("Placeholder");
+				sb.Append("{type: \"Assignment\", ");
+				sb.Append("\"destination:\" \"");
+				sb.Append(destinationVariableName);
+				sb.Append("\", operation: \"");
+				sb.Append(operation.ToString());
+				sb.Append("\", value: ");
+				sb.Append(valueExpression.ToJson(indentLevel + 1));
+				sb.Append("}");
 				return sb.ToString();
 			}
 		}
@@ -1293,9 +1327,7 @@ namespace Yarn {
 			}
 
 			internal override string ToJson(int indentLevel=0) {
-				var sb = new StringBuilder();
-				sb.Append("Placeholder");
-				return sb.ToString();
+				return "\"" + operatorType.ToString() + "\"";
 			}
 		}
 		#endregion Parse Nodes

--- a/YarnSpinner/Parser.cs
+++ b/YarnSpinner/Parser.cs
@@ -126,6 +126,11 @@ namespace Yarn {
 
 				return null;
 			}
+
+			public virtual string ToJson()
+			{
+				return "{\"nodeType\": \"ParseNode\"}";
+			}
 		}
 
 		// The top-level unit of parsing.

--- a/YarnSpinner/Parser.cs
+++ b/YarnSpinner/Parser.cs
@@ -104,8 +104,13 @@ namespace Yarn {
 			// You parse tokens into a ParseNode by using its constructor.
 			internal ParseNode(ParseNode parent, Parser p) { this.parent = parent; }
 
-			// Recursively prints the ParseNode and all of its child ParseNodes.
+			// Returns a string containing the contents of the ParseNode and 
+			// all of its child ParseNodes.
 			internal abstract string PrintTree (int indentLevel);
+
+			// Returns a string containing the contents of the ParseNode and 
+			// all of its child ParseNodes, formatted as pure JSON.
+			internal abstract string ToJson(int indentLevel=0);
 
 			public override string ToString ()
 			{
@@ -125,11 +130,6 @@ namespace Yarn {
 					!= null);					
 
 				return null;
-			}
-
-			public virtual string ToJson()
-			{
-				return "{\"nodeType\": \"ParseNode\"}";
 			}
 		}
 
@@ -165,6 +165,12 @@ namespace Yarn {
 					sb.Append( statement.PrintTree (indentLevel + 1));
 				}
 				sb.Append (Tab (indentLevel, "}"));
+				return sb.ToString();
+			}
+
+			internal override string ToJson(int indentLevel=0) {
+				var sb = new StringBuilder();
+				sb.Append("Placeholder");
 				return sb.ToString();
 			}
 
@@ -258,6 +264,11 @@ namespace Yarn {
 				throw new ArgumentNullException ();
 			}
 
+			internal override string ToJson(int indentLevel=0) {
+				var sb = new StringBuilder();
+				sb.Append("Placeholder");
+				return sb.ToString();
+			}
 		}
 
 		// Custom commands are meant to be interpreted by whatever
@@ -325,6 +336,12 @@ namespace Yarn {
 				return "";
 
 			}
+
+			internal override string ToJson(int indentLevel=0) {
+				var sb = new StringBuilder();
+				sb.Append("Placeholder");
+				return sb.ToString();
+			}
 		}
 
 		// Shortcut option groups are groups of shortcut options,
@@ -365,7 +382,11 @@ namespace Yarn {
 				return sb.ToString ();
 			}
 
-
+			internal override string ToJson(int indentLevel=0) {
+				var sb = new StringBuilder();
+				sb.Append("Placeholder");
+				return sb.ToString();
+			}
 		}
 
 		// Shortcut options are a convenient way to define new options.
@@ -416,7 +437,11 @@ namespace Yarn {
 				return sb.ToString ();
 			}
 
-
+			internal override string ToJson(int indentLevel=0) {
+				var sb = new StringBuilder();
+				sb.Append("Placeholder");
+				return sb.ToString();
+			}
 		}
 
 		// Blocks are indented groups of statements
@@ -460,6 +485,12 @@ namespace Yarn {
 				sb.Append (Tab(indentLevel, "}"));
 
 				return sb.ToString ();
+			}
+
+			internal override string ToJson(int indentLevel=0) {
+				var sb = new StringBuilder();
+				sb.Append("Placeholder");
+				return sb.ToString();
 			}
 		}
 
@@ -519,6 +550,12 @@ namespace Yarn {
 				} else {
 					return Tab (indentLevel, string.Format ("Option: -> {0}", destination));
 				}
+			}
+
+			internal override string ToJson(int indentLevel=0) {
+				var sb = new StringBuilder();
+				sb.Append("Placeholder");
+				return sb.ToString();
 			}
 		}
 
@@ -659,6 +696,12 @@ namespace Yarn {
 
 				return sb.ToString ();
 			}
+
+			internal override string ToJson(int indentLevel=0) {
+				var sb = new StringBuilder();
+				sb.Append("Placeholder");
+				return sb.ToString();
+			}
 		}
 
 		// A value, which forms part of an expression.
@@ -730,6 +773,12 @@ namespace Yarn {
 					return Tab (indentLevel, "(null)");
 				}
 				throw new ArgumentException ();
+			}
+
+			internal override string ToJson(int indentLevel=0) {
+				var sb = new StringBuilder();
+				sb.Append("Placeholder");
+				return sb.ToString();
 			}
 		}
 
@@ -1076,6 +1125,12 @@ namespace Yarn {
 
 				return Tab(indentLevel, "<error printing expression!>");
 			}
+
+			internal override string ToJson(int indentLevel=0) {
+				var sb = new StringBuilder();
+				sb.Append("Placeholder");
+				return sb.ToString();
+			}
 		}
 
 		// AssignmentStatements are things like <<set $foo = 1>>
@@ -1120,6 +1175,12 @@ namespace Yarn {
 				sb.Append (valueExpression.PrintTree (indentLevel + 1));
 				return sb.ToString ();
 
+			}
+
+			internal override string ToJson(int indentLevel=0) {
+				var sb = new StringBuilder();
+				sb.Append("Placeholder");
+				return sb.ToString();
 			}
 		}
 
@@ -1229,6 +1290,12 @@ namespace Yarn {
 			internal override string PrintTree (int indentLevel)
 			{
 				return Tab (indentLevel, operatorType.ToString ());
+			}
+
+			internal override string ToJson(int indentLevel=0) {
+				var sb = new StringBuilder();
+				sb.Append("Placeholder");
+				return sb.ToString();
 			}
 		}
 		#endregion Parse Nodes

--- a/YarnSpinnerConsole/Main.cs
+++ b/YarnSpinnerConsole/Main.cs
@@ -53,6 +53,7 @@ namespace Yarn
 			Console.WriteLine ("\t-f: Write program bytecode to file and exit.");
 			Console.WriteLine ("\t-a: Show analysis of the program and exit.");
 			Console.WriteLine ("\t-1: Automatically select the the first option when presented with options.");
+			Console.WriteLine ("\t-j: Dump parse tree to pure JSON and exit.");
 			Console.WriteLine ("\t-h: Show this message and exit.");
 
 			Environment.Exit (0);
@@ -75,6 +76,7 @@ namespace Yarn
 			bool verifyOnly = false;
 			bool autoSelectFirstOption = false;
 			bool analyseOnly = false;
+			bool dumpToJson = false;
 			string outputFile = null;
 
 			var inputFiles = new List<string> ();
@@ -175,6 +177,9 @@ namespace Yarn
 					break;
 				case "-a":
 					analyseOnly = true;
+					break;
+				case "-j":
+					dumpToJson = true;
 					break;
 				default:
 
@@ -288,6 +293,11 @@ namespace Yarn
 				using (System.IO.StreamWriter file = new System.IO.StreamWriter(outputFile, false, utf8)) {
 					file.Write(result);
 				}
+				return;
+			}
+
+			if (dumpToJson) {
+				Console.WriteLine("Should dump to json");
 				return;
 			}
 

--- a/YarnSpinnerConsole/Main.cs
+++ b/YarnSpinnerConsole/Main.cs
@@ -211,9 +211,24 @@ namespace Yarn
 				impl.SetNumber (variable.Key, variable.Value);
 			}
 
-			// Load nodes
-			var dialogue = new Dialogue(impl);
 
+
+
+			// If debugging is enabled, log debug messages; otherwise, ignore them
+			Logger debugLogger =  delegate(string message) {};
+			if (showDebugging) {
+				debugLogger = delegate(string message) {
+					Console.WriteLine ("Debug: " + message);
+				};
+			}
+
+			Logger errorLogger = delegate(string message) {
+				Console.WriteLine ("ERROR: " + message);
+			};
+
+
+			// Load nodes
+			var dialogue = new Dialogue(impl, debugLogger, errorLogger);
 
 			// Add some methods for testing
 			dialogue.library.RegisterFunction ("add_three_operands", 3, delegate(Value[] parameters) {
@@ -262,19 +277,6 @@ namespace Yarn
 			if (autoSelectFirstOption == true) {
 				impl.autoSelectFirstOption = true;
 			}
-
-			// If debugging is enabled, log debug messages; otherwise, ignore them
-			if (showDebugging) {
-				dialogue.LogDebugMessage = delegate(string message) {
-					Console.WriteLine ("Debug: " + message);
-				};
-			} else {
-				dialogue.LogDebugMessage = delegate(string message) {};
-			}
-
-			dialogue.LogErrorMessage = delegate(string message) {
-				Console.WriteLine ("ERROR: " + message);
-			};
 
 			if (verifyOnly) {
 				try {

--- a/YarnSpinnerConsole/Main.cs
+++ b/YarnSpinnerConsole/Main.cs
@@ -76,7 +76,7 @@ namespace Yarn
 			bool verifyOnly = false;
 			bool autoSelectFirstOption = false;
 			bool analyseOnly = false;
-			bool dumpToJson = false;
+			bool showJson = false;
 			string outputFile = null;
 
 			var inputFiles = new List<string> ();
@@ -179,7 +179,7 @@ namespace Yarn
 					analyseOnly = true;
 					break;
 				case "-j":
-					dumpToJson = true;
+					showJson = true;
 					break;
 				default:
 
@@ -280,14 +280,14 @@ namespace Yarn
 
 			if (verifyOnly) {
 				try {
-					dialogue.LoadFile (inputFiles [0],showTokens, showParseTree, onlyConsiderNode);
+					dialogue.LoadFile (inputFiles [0],showTokens, showParseTree, showJson, onlyConsiderNode);
 				} catch (Exception e) {
 					Console.WriteLine ("Error: " + e.Message);
 				}
 				return;
 			}
 
-			dialogue.LoadFile (inputFiles [0],showTokens, showParseTree, onlyConsiderNode);
+			dialogue.LoadFile (inputFiles [0],showTokens, showParseTree, showJson, onlyConsiderNode);
 
 			if (outputFile != null) {
 				var result = dialogue.GetByteCode();
@@ -295,11 +295,6 @@ namespace Yarn
 				using (System.IO.StreamWriter file = new System.IO.StreamWriter(outputFile, false, utf8)) {
 					file.Write(result);
 				}
-				return;
-			}
-
-			if (dumpToJson) {
-				Console.WriteLine("Should dump to json");
 				return;
 			}
 
@@ -326,6 +321,7 @@ namespace Yarn
 				showTokens == false &&
 				showParseTree == false &&
 				compileToBytecodeOnly == false &&
+				showJson == false &&
 				analyseOnly == false;
 
 			if (runProgram) {

--- a/YarnSpinnerTests/Test.cs
+++ b/YarnSpinnerTests/Test.cs
@@ -39,15 +39,13 @@ namespace YarnSpinner.Tests
 			}
 
 
-			dialogue = new Yarn.Dialogue (storage);
-
-			dialogue.LogDebugMessage = delegate(string message) {
-				
+			Logger debugLogger = delegate(string message) {
 				Console.WriteLine (message);
-
 			};
 
-			dialogue.LogErrorMessage = delegate(string message) {
+
+
+			Logger errorLogger = delegate(string message) {
 				Console.ForegroundColor = ConsoleColor.Red;
 				Console.WriteLine ("ERROR: " + message);
 				Console.ResetColor ();
@@ -55,6 +53,9 @@ namespace YarnSpinner.Tests
 				if (errorsCauseFailures == true)
 					Assert.Fail();
 			};
+
+			dialogue = new Yarn.Dialogue (storage, debugLogger, errorLogger);
+
 
 			dialogue.library.RegisterFunction ("assert", -1, delegate(Yarn.Value[] parameters) {
 				if (parameters[0].AsBool == false) {


### PR DESCRIPTION
I wanted to use Yarn from Rust, and after a week of noodling around with writing parsers I just said "well I already know how to use a REALLY GOOD JSON reading library, why don't I just modify YarnSpinner to output a parse tree as JSON?"

Of course it would be even cooler to just make the Yarn tool output the right syntax, but, eh, Javascript.

So I added a JSON output mode to YarnSpinnerConsole.  Whether or not you guys are interested in it, I don't know!  If you want, I am happy to reformat it to whatever standards you want and add unit tests, if I can figure out how to.

This did involve a little refactoring of the Loader and Dialogue objects to make it convenient, see the commit message for the first commit.