### PR TITLE
Fix localization typo

### DIFF
--- a/Documentation/YarnSpinner-Dialogue/Dialogue-Localization.md
+++ b/Documentation/YarnSpinner-Dialogue/Dialogue-Localization.md
@@ -1,7 +1,7 @@
-# Localisation
+# Localization
 Yarn Spinner provides tools to help convert your game in to any language you like. This is achieved by usage of the [YarnSpinnerConsole](../YarnSpinnerConsole) tool. At the moment, this tool is not available standalone and needs to be [built from source](../YarnSpinner-Programming/Building.md).
 
-## Localisation procedure
+## Localization procedure
 
 1. We first use the tool to place unique **taglines** on each line of text that the end user will see. To do this, we execute the tool with the **taglines** command, eg:  `YarnSpinnerConsole.exe taglines MyYarnFile.yarn.txt`.
 
@@ -13,8 +13,8 @@ Yarn Spinner provides tools to help convert your game in to any language you lik
 3. When the file is returned from translators, we then use Yarn Spinner's DialogueRunner inside Unity to set String Groups for the required language.
 <!-- Placeholder for image of DialogueRunner -->
 ## Footnotes
-* While not essential that all files follow a standard, but highly recommended that consistency of format be used across all localisation files within a project eg [ISO-15897](https://www.iso.org/obp/ui/#iso:std:iso-iec:15897:ed-2:v1:en)
+* While not essential that all files follow a standard, but highly recommended that consistency of format be used across all localization files within a project eg [ISO-15897](https://www.iso.org/obp/ui/#iso:std:iso-iec:15897:ed-2:v1:en)
 * Originally, Yarn Spinner used .json format. The Yarn Spinner Console can convert this json format to the new improved text format: `YarnSpinnerConsole.exe convert --yarn Ship.json`
-* Command reference is available for YarnSpinnerConsole.exe by either running it with no arguments or by utilising the help command (`YarnSpinnerConsole.exe help`). Help for each command is available by using 'help command' (eg `YarnSpinnderConsole.exe help compile`)
+* Command reference is available for YarnSpinnerConsole.exe by either running it with no arguments or by utilizing the help command (`YarnSpinnerConsole.exe help`). Help for each command is available by using 'help command' (eg `YarnSpinnerConsole.exe help compile`)
 
 

--- a/Documentation/YarnSpinner-Dialogue/Localization.md
+++ b/Documentation/YarnSpinner-Dialogue/Localization.md
@@ -1,7 +1,7 @@
 # LOCALIZATION
 Yarn Spinner provides tools to help convert your game in to any language you like. This is achieved by usage of the [YarnSpinnerConsole](../YarnSpinnerConsole) tool. At the moment, this tool is not available standalone and needs to be [built from source](../YarnSpinner-Programming/Building.md).
 
-## Localisation procedure
+## Localization procedure
 
 1. We first use the tool to place unique **taglines** on each line of text that the end user will see. To do this, we execute the tool with the **taglines** command, eg:  `YarnSpinnerConsole.exe taglines MyYarnFile.yarn.txt`.
 
@@ -13,8 +13,8 @@ Yarn Spinner provides tools to help convert your game in to any language you lik
 3. When the file is returned from translators, we then use Yarn Spinner's DialogueRunner inside Unity to set String Groups for the required language.
 <!-- Placeholder for image of DialogueRunner -->
 ## Footnotes
-* While not essential that all files follow a standard, but highly recommended that consistency of format be used across all localisation files within a project eg [ISO-15897](https://www.iso.org/obp/ui/#iso:std:iso-iec:15897:ed-2:v1:en)
+* While not essential that all files follow a standard, but highly recommended that consistency of format be used across all localization files within a project eg [ISO-15897](https://www.iso.org/obp/ui/#iso:std:iso-iec:15897:ed-2:v1:en)
 * Originally, Yarn Spinner used .json format. The Yarn Spinner Console can convert this json format to the new improved text format: `YarnSpinnerConsole.exe convert --yarn Ship.json`
-* Command reference is available for YarnSpinnerConsole.exe by either running it with no arguments or by utilising the help command (`YarnSpinnerConsole.exe help`). Help for each command is available by using 'help command' (eg `YarnSpinnderConsole.exe help compile`)
+* Command reference is available for YarnSpinnerConsole.exe by either running it with no arguments or by utilizing the help command (`YarnSpinnerConsole.exe help`). Help for each command is available by using 'help command' (eg `YarnSpinnderConsole.exe help compile`)
 
 

--- a/Documentation/YarnSpinner-Dialogue/README.md
+++ b/Documentation/YarnSpinner-Dialogue/README.md
@@ -10,10 +10,10 @@ In [our simple example](Simple-Dialogue-Example.md), we will create a very simpl
 ### Complex Example Dialogue
 In the [complex example](Complex-Dialogue-Example.md), we will create a slightly more complex Dialogue to the simple example above. This example demonstrates more advanced possibilities that exist within telling stories in a narrative game environment. 
 
-### Localisation
-Our [localisation](Dialogue-Localisation.md) document describes how localisation,
+### Localization
+Our [localization](Dialogue-Localization.md) document describes how localization,
 or translating the text into other languages, takes place.
 > ***Note:*** At the moment, it is a requirement that a programmer run a special tool across the Dialogue to produce the files to be translated.
 
 ### General Usage
-We have a page of [general usage](Advanced-Dialogue-Usage.md), describing many further features of the Yarn Language. It also containins small Dialogue snippets as well as tips and suggestions you might find useful.
+We have a page of [general usage](Advanced-Dialogue-Usage.md), describing many further features of the Yarn Language. It also contains small Dialogue snippets as well as tips and suggestions you might find useful.

--- a/YarnSpinner/Properties/AssemblyInfo.cs
+++ b/YarnSpinner/Properties/AssemblyInfo.cs
@@ -51,7 +51,7 @@ using System.Runtime.CompilerServices;
 //[assembly: AssemblyDelaySign(false)]
 //[assembly: AssemblyKeyFile("")]
 
-// Make internals available to the localisation tool
+// Make internals available to the localization tool
 [assembly: InternalsVisibleTo("YarnSpinnerConsole")]
 [assembly: InternalsVisibleTo("YarnSpinnerTests")]
 

--- a/YarnSpinnerConsole/Main.cs
+++ b/YarnSpinnerConsole/Main.cs
@@ -112,7 +112,7 @@ namespace Yarn
         public string onlyUseTag { get; set; }
     }
 
-    [Verb("taglines", HelpText = "Adds localisation tags to the provided files, where necessary.")]
+    [Verb("taglines", HelpText = "Adds localization tags to the provided files, where necessary.")]
     class AddLabelsOptions : BaseOptions
     {
 


### PR DESCRIPTION
There's an inconsistency with the usage of localization and localisation. I figured it would be a good idea to just make everything use localization.