### PR TITLE
Added `Get Tag from Nodes` to Dialog

### DIFF
--- a/YarnSpinner/Dialogue.cs
+++ b/YarnSpinner/Dialogue.cs
@@ -500,6 +500,34 @@ namespace Yarn {
             }
         }
 
+		public Dictionary<string, IEnumerable<string>> GetTagsForAllNodes() {
+			var d = new Dictionary<string,IEnumerable<string>>();
+
+			foreach (var node in program.nodes) {
+				var tags = program.GetTagsForNode(node.Key);
+
+				if (tags == null)
+					continue;
+
+				d [node.Key] = tags;
+			}
+
+			return d;
+		}
+
+		/// Returns the tags for the node 'nodeName'.
+		public IEnumerable<string> GetTagsForNode(string nodeName) {
+			if (program.nodes.Count == 0) {
+				LogErrorMessage ("No nodes are loaded!");
+				return null;
+			} else if (program.nodes.ContainsKey(nodeName)) {
+				return program.GetTagsForNode (nodeName);
+			} else {
+				LogErrorMessage ("No node named " + nodeName);
+				return null;
+			}
+		}
+
         public void AddStringTable(Dictionary<string, string> stringTable)
         {
             program.LoadStrings(stringTable);

--- a/YarnSpinner/Program.cs
+++ b/YarnSpinner/Program.cs
@@ -217,6 +217,11 @@ namespace Yarn
 			return this.GetString(nodes[nodeName].sourceTextStringID);
 		}
 
+		public IEnumerable<string> GetTagsForNode(string nodeName)
+		{
+			return nodes[nodeName].tags;
+		}
+
 		public void Include(Program otherProgram)
 		{
 			foreach (var otherNodeName in otherProgram.nodes)

--- a/YarnSpinnerTests/DialogueTests.cs
+++ b/YarnSpinnerTests/DialogueTests.cs
@@ -137,6 +137,19 @@ namespace YarnSpinner.Tests
 
             Assert.AreEqual (source, "A: HAHAHA");
         }
+		[Test]
+		public void TestGettingTags() {
+
+			dialogue.LoadFile (Path.Combine(TestDataPath, "Example.yarn.txt"));
+
+			var source = dialogue.GetTagsForNode ("LearnMore");
+
+			Assert.IsNotNull (source);
+
+			Assert.IsNotEmpty (source);
+
+			Assert.AreEqual (source.First(), "rawText");
+		}
 
         [Test]
         public void TestNodeVistation() {


### PR DESCRIPTION
Program exposes node tags by name:

```
GetTagsForNode(nodeName);
```

Dialogue follows the same behavior:

```
GetTagsForAllNodes();
GetTagsForNode(nodeName);
```