### PR TITLE
Removing unused variable: expression

### DIFF
--- a/YarnSpinner/AntlrCompiler.cs
+++ b/YarnSpinner/AntlrCompiler.cs
@@ -584,7 +584,7 @@ namespace Yarn
         // -expression
         public override int VisitExpNegative(YarnSpinnerParser.ExpNegativeContext context)
         {
-            int expression = Visit(context.expression());
+            Visit(context.expression());
 
             // TODO: temp operator call
             compiler.Emit(ByteCode.CallFunc, TokenType.UnaryMinus.ToString());


### PR DESCRIPTION
This variable is not used, and generates compiler warnings.