### PR TITLE
Added code analyzers and fixed locale issues.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,3 +6,4 @@ The following people have contributed to the development of Yarn Spinner. If you
 * 2017: Rev Peter Lawler <relwalretep@gmail.com>
 * 2017: Dr Tim 'McJones' Nugent <tim@lonely.coffee>
 * 2018: Damon 'demanrisu' Reece <de@coy.ninja>
+* 2019: Tamme Schichler <tamme@schichler.dev>

--- a/YarnSpinner/Analyser.cs
+++ b/YarnSpinner/Analyser.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace Yarn.Analysis
 {
@@ -56,10 +57,10 @@ namespace Yarn.Analysis
 
                 contextLabel += this.nodeName;
                 if (this.lineNumber != -1) {
-                    contextLabel += string.Format (": {0}", this.lineNumber);
+                    contextLabel += string.Format (CultureInfo.CurrentCulture, ": {0}", this.lineNumber);
 
                     if (this.columnNumber != -1) {
-                        contextLabel += string.Format (":{0}", this.columnNumber);
+                        contextLabel += string.Format (CultureInfo.CurrentCulture, ":{0}", this.columnNumber);
                     }
                 }
             }
@@ -69,7 +70,7 @@ namespace Yarn.Analysis
             if (string.IsNullOrEmpty(contextLabel)) {
                 message = this.message;
             } else {
-                message = string.Format ("{0}: {1}", contextLabel, this.message);
+                message = string.Format (CultureInfo.CurrentCulture, "{0}: {1}", contextLabel, this.message);
             }
 
             return message;
@@ -235,12 +236,12 @@ namespace Yarn.Analysis
             var diagnoses = new List<Diagnosis>();
 
             foreach (var readOnlyVariable in readOnlyVariables) {
-                var message = string.Format ("Variable {0} is read from, but never assigned", readOnlyVariable);
+                var message = string.Format (CultureInfo.CurrentCulture, "Variable {0} is read from, but never assigned", readOnlyVariable);
                 diagnoses.Add(new Diagnosis (message, Diagnosis.Severity.Warning));
             }
 
             foreach (var writeOnlyVariable in writeOnlyVariables) {
-                var message = string.Format ("Variable {0} is assigned, but never read from", writeOnlyVariable);
+                var message = string.Format (CultureInfo.CurrentCulture, "Variable {0} is assigned, but never read from", writeOnlyVariable);
                 diagnoses.Add(new Diagnosis (message, Diagnosis.Severity.Warning));
             }
 

--- a/YarnSpinner/AntlrCompiler.cs
+++ b/YarnSpinner/AntlrCompiler.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Antlr4.Runtime.Misc;
 using Antlr4.Runtime;
 using Antlr4.Runtime.Tree;
+using System.Globalization;
 
 namespace Yarn
 {
@@ -75,7 +76,7 @@ namespace Yarn
                 foreach (var hashtag in context.hashtag())
                 {
                     string tagText = hashtag.GetText().Trim('#');
-                    if (tagText.StartsWith("line:"))
+                    if (tagText.StartsWith("line:", StringComparison.InvariantCulture))
                     {
                         return tagText;
                     }
@@ -102,7 +103,7 @@ namespace Yarn
             if (currentNode != null)
             {
                 string newNode = context.header().header_title().TITLE_TEXT().GetText().Trim();
-                string message = string.Format("Discovered a new node {0} while {1} is still being parsed", newNode, currentNode.name);
+                string message = string.Format(CultureInfo.CurrentCulture, "Discovered a new node {0} while {1} is still being parsed", newNode, currentNode.name);
 				throw new Yarn.ParseException(message);
             }
             currentNode = new Node();
@@ -125,7 +126,7 @@ namespace Yarn
         {
             if (context.header_tag().Length > 1)
             {
-                string message = string.Format("Too many header tags defined inside {0}", context.header_title().TITLE_TEXT().GetText().Trim());
+                string message = string.Format(CultureInfo.CurrentCulture, "Too many header tags defined inside {0}", context.header_title().TITLE_TEXT().GetText().Trim());
                 throw new Yarn.ParseException(message);
             }
         }
@@ -711,7 +712,7 @@ namespace Yarn
         }
         public override int VisitValueNumber(YarnSpinnerParser.ValueNumberContext context)
         {
-            float number = float.Parse(context.BODY_NUMBER().GetText());
+            float number = float.Parse(context.BODY_NUMBER().GetText(), CultureInfo.InvariantCulture);
             compiler.Emit(ByteCode.PushNumber, number);
 
             return 0;

--- a/YarnSpinner/Compiler.cs
+++ b/YarnSpinner/Compiler.cs
@@ -191,7 +191,7 @@ namespace Yarn
             // TODO: This will use only the first #line: tag, ignoring all others
             foreach (var tag in node.tags)
             {
-                if (tag.StartsWith("line:"))
+                if (tag.StartsWith("line:", StringComparison.InvariantCulture))
                 {
                     return tag;
                 }

--- a/YarnSpinner/Dialogue.cs
+++ b/YarnSpinner/Dialogue.cs
@@ -27,12 +27,17 @@ SOFTWARE.
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
+using System.Runtime.Serialization;
 
 namespace Yarn {
 
     /// Represents things that can go wrong while loading or running a dialogue.
+    [Serializable]
     public  class YarnException : Exception {
         public YarnException(string message) : base(message) {}
+
+        protected YarnException(SerializationInfo serializationInfo, StreamingContext streamingContext) : base(serializationInfo, streamingContext) {}
     }
 
     // Delegates, which are used by the client.
@@ -45,13 +50,16 @@ namespace Yarn {
     /// and error logging.
     public delegate void Logger(string message);
 
+
     /// Information about stuff that the client should handle.
     /** (Currently this just wraps a single field, but doing it like this
      * gives us the option to add more stuff later without breaking the API.)
      */
+#pragma warning disable CA1815 // Override equals and operator equals on value types. Justification: None. This should be fixed eventually to prevent unexpected behaviour down the line.
     public struct Line { public string text; }
     public struct Options { public IList<string> options; }
     public struct Command { public string text; }
+#pragma warning restore CA1815 // Override equals and operator equals on value types
 
     /// Where we turn to for storing and loading variable data.
     public interface VariableStorage {
@@ -218,13 +226,13 @@ namespace Yarn {
 
                 // Ensure this node exists
                 if (NodeExists (nodeName) == false) {
-                    var errorMessage = string.Format ("The node {0} does not " + "exist.", nodeName);
+                    var errorMessage = string.Format (CultureInfo.CurrentCulture, "The node {0} does not " + "exist.", nodeName);
                     LogErrorMessage (errorMessage);
                     return 0;
                 }
             } else {
                 // We got too many parameters
-                var errorMessage = string.Format ("Incorrect number of parameters to " + "visitCount (expected 0 or 1, got {0})", parameters.Length);
+                var errorMessage = string.Format (CultureInfo.CurrentCulture, "Incorrect number of parameters to " + "visitCount (expected 0 or 1, got {0})", parameters.Length);
                 LogErrorMessage (errorMessage);
                 return 0;
             }
@@ -265,7 +273,7 @@ namespace Yarn {
         public void LoadFile(string fileName, bool showTokens = false, bool showParseTree = false, string onlyConsiderNode=null) {
 
             // Is this a compiled program file?
-            if (fileName.EndsWith(".yarn.bytes")) {
+            if (fileName.EndsWith(".yarn.bytes", StringComparison.InvariantCulture)) {
 
                 var bytes = System.IO.File.ReadAllBytes(fileName);
                 LoadCompiledProgram(bytes, fileName);
@@ -332,7 +340,7 @@ namespace Yarn {
                     }
                     catch (Newtonsoft.Json.JsonReaderException e)
                     {
-                        LogErrorMessage(string.Format("Cannot load compiled program: {0}", e.Message));
+                        LogErrorMessage(string.Format(CultureInfo.CurrentCulture, "Cannot load compiled program: {0}", e.Message));
                     }
                 }
             }

--- a/YarnSpinner/ErrorListener.cs
+++ b/YarnSpinner/ErrorListener.cs
@@ -2,6 +2,7 @@
 using Antlr4.Runtime;
 using System.Text;
 using System.IO;
+using System.Globalization;
 
 namespace Yarn
 {
@@ -23,7 +24,7 @@ namespace Yarn
 
             // the human readable message
             object[] format = new object[] { line, charPositionInLine + 1 };
-            builder.AppendFormat("Error on line {0} at position {1}:\n", format);
+            builder.AppendFormat(CultureInfo.CurrentCulture, "Error on line {0} at position {1}:\n", format);
             // the actual error message
             builder.AppendLine(msg);
 

--- a/YarnSpinner/GlobalSuppressions.cs
+++ b/YarnSpinner/GlobalSuppressions.cs
@@ -1,0 +1,18 @@
+﻿
+// This file is used by Code Analysis to maintain SuppressMessage 
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given 
+// a specific target and scoped to a namespace, type, member, etc.
+
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1032:Implement standard exception constructors", Justification = "The exception constructors are by convention. It's nicer to have them (so they're available if necessary in the future), but it's not entirely required and won't hurt correctness.")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1051:Do not declare visible instance fields", Justification = "These should be properties, ideally, but I don't know if I can fix that easily right now without breaking anything.")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1034:Nested types should not be visible", Justification = "Just a style guide thing.")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2208:Instantiate argument exceptions correctly", Justification = "This SHOULD be fixed (to have more useful error messages), but it's out of scope for fixing locale issues.")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "I think this rule is useless.")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1820:Test for empty strings using string length", Justification = "SHOULD be fixed for performance, but it's not pressing.")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "This would save a null check, but it's not that important.")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1041:Provide ObsoleteAttribute message", Justification = "Should be fixed. It's currently unclear what changed or how to adapt usage.")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores", Justification = "Just style.")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1715:Identifiers should have correct prefix", Justification = "Just style.")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA1801:Review unused parameters", Justification = "Should be fixed eventually.")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1064:Exceptions should be public", Justification = "Only if they really are part of the public API.")]

--- a/YarnSpinner/Lexer.cs
+++ b/YarnSpinner/Lexer.cs
@@ -27,6 +27,7 @@ SOFTWARE.
 using System;
 using System.Text.RegularExpressions;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace Yarn {
 
@@ -37,7 +38,7 @@ namespace Yarn {
 
         public TokeniserException (string message) : base (message) {}
         public TokeniserException (int lineNumber, int columnNumber, string message)
-            : base(string.Format ("{0}:{1}: {2}", lineNumber, columnNumber, message))
+            : base(string.Format (CultureInfo.CurrentCulture, "{0}:{1}: {2}", lineNumber, columnNumber, message))
         {
             this.lineNumber = lineNumber;
             this.columnNumber = columnNumber;
@@ -59,7 +60,7 @@ namespace Yarn {
                 nameList = names [0];
             }
 
-            var message = string.Format ("Expected {0}", nameList);
+            var message = string.Format (CultureInfo.CurrentCulture, "Expected {0}", nameList);
 
             return new TokeniserException (lineNumber, columnNumber, message);
         }
@@ -201,9 +202,9 @@ namespace Yarn {
 
         public override string ToString() {
             if (this.value != null) {
-                return string.Format("{0} ({1}) at {2}:{3} (state: {4})", type.ToString(), value.ToString(), lineNumber, columnNumber, lexerState);
+                return string.Format(CultureInfo.CurrentCulture, "{0} ({1}) at {2}:{3} (state: {4})", type.ToString(), value, lineNumber, columnNumber, lexerState);
             } else {
-                return string.Format ("{0} at {1}:{2} (state: {3})", type, lineNumber, columnNumber, lexerState);
+                return string.Format (CultureInfo.CurrentCulture, "{0} at {1}:{2} (state: {3})", type, lineNumber, columnNumber, lexerState);
             }
         }
     }
@@ -225,7 +226,7 @@ namespace Yarn {
 
             public TokenRule AddTransition(TokenType type, string entersState = null, bool delimitsText = false) {
 
-                var pattern = string.Format (@"\G{0}", patterns [type]);
+                var pattern = string.Format (CultureInfo.InvariantCulture, @"\G{0}", patterns [type]);
 
                 var rule = new TokenRule (type, new Regex(pattern), entersState, delimitsText);
 
@@ -246,12 +247,12 @@ namespace Yarn {
 
                 foreach (var otherRule in tokenRules) {
                     if (otherRule.delimitsText == true)
-                        delimiterRules.Add (string.Format ("({0})", otherRule.regex.ToString().Substring(2)));
+                        delimiterRules.Add (string.Format (CultureInfo.InvariantCulture, "({0})", otherRule.regex.ToString().Substring(2)));
                 }
 
                 // Create a regex that matches all text up to but not including
                 // any of the delimiter rules
-                var pattern = string.Format (@"\G((?!{0}).)*",
+                var pattern = string.Format (CultureInfo.InvariantCulture, @"\G((?!{0}).)*",
                     string.Join ("|", delimiterRules.ToArray()));
 
                 var rule = AddTransition(type, entersState);
@@ -295,7 +296,7 @@ namespace Yarn {
 
             public override string ToString ()
             {
-                return string.Format (string.Format ("[TokenRule: {0} - {1}]", type, this.regex));
+                return string.Format(CultureInfo.InvariantCulture, "[TokenRule: {0} - {1}]", type, this.regex);
             }
 
         }
@@ -549,7 +550,7 @@ namespace Yarn {
 
                 // If we're about to hit a line comment, abort processing line
                 // immediately
-                if (line.Substring(columnNumber).StartsWith(LINE_COMMENT)) {
+                if (line.Substring(columnNumber).StartsWith(LINE_COMMENT, StringComparison.InvariantCulture)) {
                     break;
                 }
 

--- a/YarnSpinner/Library.cs
+++ b/YarnSpinner/Library.cs
@@ -1,10 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace Yarn
 {
     public delegate Object ReturningFunction (params Value[] parameters);
+#pragma warning disable CA1716 // Identifiers should not match keywords
     public delegate void Function (params Value[] parameters);
+#pragma warning restore CA1716 // Identifiers should not match keywords
 
     public class FunctionInfo {
 
@@ -50,7 +53,7 @@ namespace Yarn
                     return Value.NULL; // a null Value
                 }
             } else {
-                string error = string.Format (
+                string error = string.Format (CultureInfo.CurrentCulture,
                     "Incorrect number of parameters for function {0} (expected {1}, got {2}",
                     this.name,
                     this.paramCount,

--- a/YarnSpinner/Loader.cs
+++ b/YarnSpinner/Loader.cs
@@ -36,6 +36,7 @@ using Antlr4.Runtime.Tree;
 using System.Text;
 using System.IO;
 using System.Linq;
+using System.Globalization;
 
 namespace Yarn {
 
@@ -62,7 +63,7 @@ namespace Yarn {
             // Sum up the result
             var sb = new System.Text.StringBuilder();
             foreach (var t in tokenList) {
-                sb.AppendLine (string.Format("{0} ({1} line {2})", t.ToString (), t.context, t.lineNumber));
+                sb.AppendLine (string.Format(CultureInfo.CurrentCulture, "{0} ({1} line {2})", t.ToString (), t.context, t.lineNumber));
             }
 
             // Let's see what we got
@@ -81,7 +82,7 @@ namespace Yarn {
         // Prepares a loader. 'implementation' is used for logging.
         public Loader(Dialogue dialogue) {
             if (dialogue == null)
-                throw new ArgumentNullException ("dialogue");
+                throw new ArgumentNullException (nameof(dialogue));
 
             this.dialogue = dialogue;
 
@@ -140,7 +141,7 @@ namespace Yarn {
                     int lineIndent = tweakedLine.TakeWhile(Char.IsWhiteSpace).Count();
 
                     // working out if it is an option (ie does it start with ->)
-                    bool isOption = tweakedLine.TrimStart(' ').StartsWith(OPTION);
+                    bool isOption = tweakedLine.TrimStart(' ').StartsWith(OPTION, StringComparison.InvariantCulture);
 
                     // are we in a state where we need to track indents?
                     var previous = indents.Peek();
@@ -320,17 +321,17 @@ namespace Yarn {
                     catch (Yarn.TokeniserException t)
                     {
                         // Add file information
-                        var message = string.Format("In file {0}: Error reading node {1}: {2}", fileName, nodeInfo.title, t.Message);
+                        var message = string.Format(CultureInfo.CurrentCulture, "In file {0}: Error reading node {1}: {2}", fileName, nodeInfo.title, t.Message);
                         throw new Yarn.TokeniserException(message);
                     }
                     catch (Yarn.ParseException p)
                     {
-                        var message = string.Format("In file {0}: Error parsing node {1}: {2}", fileName, nodeInfo.title, p.Message);
+                        var message = string.Format(CultureInfo.CurrentCulture, "In file {0}: Error parsing node {1}: {2}", fileName, nodeInfo.title, p.Message);
                         throw new Yarn.ParseException(message);
                     }
                     catch (InvalidOperationException e)
                     {
-                        var message = string.Format("In file {0}: Error reading node {1}: {2}", fileName, nodeInfo.title, e.Message);
+                        var message = string.Format(CultureInfo.CurrentCulture, "In file {0}: Error reading node {1}: {2}", fileName, nodeInfo.title, e.Message);
                         throw new InvalidOperationException(message);
                     }
 #endif
@@ -404,7 +405,7 @@ namespace Yarn {
                 format = NodeFormat.SingleNodeText;
             }
             else {
-                throw new FormatException(string.Format("Unknown file format for file '{0}'", fileName));
+                throw new FormatException(string.Format(CultureInfo.CurrentCulture, "Unknown file format for file '{0}'", fileName));
             }
 
             return format;
@@ -480,7 +481,7 @@ namespace Yarn {
 
                                 if (headerMatches == null)
                                 {
-                                    dialogue.LogErrorMessage(string.Format("Line {0}: Can't parse header '{1}'", lineNumber, line));
+                                    dialogue.LogErrorMessage(string.Format(CultureInfo.CurrentCulture, "Line {0}: Can't parse header '{1}'", lineNumber, line));
                                     continue;
                                 }
 
@@ -509,7 +510,7 @@ namespace Yarn {
                                         }
                                         else if (propertyType.IsAssignableFrom(typeof(int)))
                                         {
-                                            convertedValue = int.Parse(value);
+                                            convertedValue = int.Parse(value, CultureInfo.InvariantCulture);
                                         }
                                         else if (propertyType.IsAssignableFrom(typeof(NodeInfo.Position)))
                                         {
@@ -522,8 +523,8 @@ namespace Yarn {
                                             }
 
                                             var position = new NodeInfo.Position();
-                                            position.x = int.Parse(components[0]);
-                                            position.y = int.Parse(components[1]);
+                                            position.x = int.Parse(components[0], CultureInfo.InvariantCulture);
+                                            position.y = int.Parse(components[1], CultureInfo.InvariantCulture);
 
                                             convertedValue = position;
                                         }
@@ -539,11 +540,11 @@ namespace Yarn {
                                     }
                                     catch (FormatException)
                                     {
-                                        dialogue.LogErrorMessage(string.Format("{0}: Error setting '{1}': invalid value '{2}'", lineNumber, field, value));
+                                        dialogue.LogErrorMessage(string.Format(CultureInfo.CurrentCulture, "{0}: Error setting '{1}': invalid value '{2}'", lineNumber, field, value));
                                     }
                                     catch (NotSupportedException)
                                     {
-                                        dialogue.LogErrorMessage(string.Format("{0}: Error setting '{1}': This property cannot be set", lineNumber, field));
+                                        dialogue.LogErrorMessage(string.Format(CultureInfo.CurrentCulture, "{0}: Error setting '{1}': This property cannot be set", lineNumber, field));
                                     }
                                 }
                             } while ((line = reader.ReadLine()) != "---");

--- a/YarnSpinner/Parser.cs
+++ b/YarnSpinner/Parser.cs
@@ -27,6 +27,7 @@ SOFTWARE.
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Runtime.Serialization;
 using System.Text;
 
@@ -523,9 +524,9 @@ namespace Yarn {
             internal override string PrintTree (int indentLevel)
             {
                 if (label != null) {
-                    return Tab (indentLevel, string.Format ("Option: \"{0}\" -> {1}", label, destination));
+                    return Tab (indentLevel, string.Format (CultureInfo.CurrentCulture, "Option: \"{0}\" -> {1}", label, destination));
                 } else {
-                    return Tab (indentLevel, string.Format ("Option: -> {0}", destination));
+                    return Tab (indentLevel, string.Format (CultureInfo.CurrentCulture, "Option: -> {0}", destination));
                 }
             }
         }
@@ -678,7 +679,7 @@ namespace Yarn {
                 switch (t.type) {
                 case TokenType.Number:
 
-                    value = new Value (float.Parse (t.value as String));
+                    value = new Value (float.Parse (t.value as string, CultureInfo.InvariantCulture));
 
                     break;
                 case TokenType.String:
@@ -726,11 +727,11 @@ namespace Yarn {
             {
                 switch (value.type) {
                 case Value.Type.Number:
-                    return Tab (indentLevel, value.numberValue.ToString());
+                    return Tab (indentLevel, value.numberValue.ToString(CultureInfo.CurrentCulture));
                 case Value.Type.String:
-                    return Tab(indentLevel, String.Format("\"{0}\"", value.stringValue));
+                    return Tab(indentLevel, string.Format(CultureInfo.CurrentCulture, "\"{0}\"", value.stringValue));
                 case Value.Type.Bool:
-                    return Tab (indentLevel, value.boolValue.ToString());
+                    return Tab (indentLevel, value.boolValue.ToString(CultureInfo.CurrentCulture));
                 case Value.Type.Variable:
                     return Tab (indentLevel, value.variableName);
                 case Value.Type.Null:
@@ -995,7 +996,7 @@ namespace Yarn {
 
                             // Ensure that this call has the right number of params
                             if (info.IsParameterCountCorrect(next.parameterCount) == false) {
-                                string error = string.Format("Error parsing expression: " +
+                                string error = string.Format(CultureInfo.CurrentCulture, "Error parsing expression: " +
                                     "Unsupported number of parameters for function {0} (expected {1}, got {2})",
                                     next.value as String,
                                     info.paramCount,

--- a/YarnSpinner/Program.cs
+++ b/YarnSpinner/Program.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using System.Runtime.Serialization;
+using System.Globalization;
 
 namespace Yarn
 {
@@ -24,7 +25,7 @@ namespace Yarn
 			}
 
 			string possibleValues = string.Join(",", expectedTypeNames.ToArray());
-			string message = string.Format("Line {0}:{1}: Expected {2}, but found {3}",
+			string message = string.Format(CultureInfo.CurrentCulture, "Line {0}:{1}: Expected {2}, but found {3}",
 										   lineNumber,
 										   foundToken.columnNumber,
 										   possibleValues,
@@ -38,7 +39,7 @@ namespace Yarn
 		internal static ParseException Make(Token mostRecentToken, string message)
 		{
 			var lineNumber = mostRecentToken.lineNumber + 1;
-			string theMessage = string.Format("Line {0}:{1}: {2}",
+			string theMessage = string.Format(CultureInfo.CurrentCulture, "Line {0}:{1}: {2}",
 								 lineNumber,
 								mostRecentToken.columnNumber,
 								 message);
@@ -56,7 +57,7 @@ namespace Yarn
 			int end = context.Stop.StopIndex;
             string body = context.Start.InputStream.GetText(new Antlr4.Runtime.Misc.Interval(start, end));
 
-            string theMessage = String.Format("Error on line {0}\n{1}\n{2}",line,body,message);
+            string theMessage = string.Format(CultureInfo.CurrentCulture, "Error on line {0}\n{1}\n{2}", line,body,message);
 
             var e = new ParseException(theMessage);
             e.lineNumber = line;
@@ -105,7 +106,7 @@ namespace Yarn
 				var result = new Dictionary<string, string>();
 				foreach (var line in strings)
 				{
-					if (line.Key.StartsWith("line:"))
+					if (line.Key.StartsWith("line:", StringComparison.InvariantCulture))
 					{
 						continue;
 					}
@@ -135,7 +136,7 @@ namespace Yarn
 			string key;
 
 			if (lineID == null)
-				key = string.Format("{0}-{1}", nodeName, stringCount++);
+				key = string.Format(CultureInfo.InvariantCulture, "{0}-{1}", nodeName, stringCount++);
 			else
 				key = lineID;
 
@@ -185,11 +186,11 @@ namespace Yarn
 
 					if (instructionCount % 5 == 0 || instructionCount == entry.Value.instructions.Count - 1)
 					{
-						preface = string.Format("{0,6}   ", instructionCount);
+						preface = string.Format(CultureInfo.InvariantCulture, "{0,6}   ", instructionCount);
 					}
 					else
 					{
-						preface = string.Format("{0,6}   ", " ");
+						preface = string.Format(CultureInfo.InvariantCulture, "{0,6}   ", " ");
 					}
 
 					sb.AppendLine(preface + instructionText);
@@ -206,7 +207,7 @@ namespace Yarn
 			{
 				var lineInfo = this.lineInfo[entry.Key];
 
-                sb.AppendLine(string.Format("{0}: {1} ({2}:{3})", entry.Key, entry.Value, lineInfo.nodeName, lineInfo.lineNumber));
+                sb.AppendLine(string.Format(CultureInfo.InvariantCulture, "{0}: {1} ({2}:{3})", entry.Key, entry.Value, lineInfo.nodeName, lineInfo.lineNumber));
 			}
 
 			return sb.ToString();
@@ -224,7 +225,7 @@ namespace Yarn
 
 				if (nodes.ContainsKey(otherNodeName.Key))
 				{
-					throw new InvalidOperationException(string.Format("This program already contains a node named {0}", otherNodeName.Key));
+					throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, "This program already contains a node named {0}", otherNodeName.Key));
 				}
 
 				nodes[otherNodeName.Key] = otherNodeName.Value;
@@ -235,7 +236,7 @@ namespace Yarn
 
 				if (nodes.ContainsKey(otherString.Key))
 				{
-					throw new InvalidOperationException(string.Format("This program already contains a string with key {0}", otherString.Key));
+					throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, "This program already contains a string with key {0}", otherString.Key));
 				}
 
 				strings[otherString.Key] = otherString.Value;
@@ -275,8 +276,8 @@ namespace Yarn
 			}
 
 			// Convert the operands to strings
-			var opAString = operandA != null ? operandA.ToString() : "";
-			var opBString = operandB != null ? operandB.ToString() : "";
+			var opAString = operandA != null ? Convert.ToString(operandA, CultureInfo.InvariantCulture) : "";
+			var opBString = operandB != null ? Convert.ToString(operandB, CultureInfo.InvariantCulture) : "";
 
 			// Generate a comment, if the instruction warrants it
 			string comment = "";
@@ -324,11 +325,11 @@ namespace Yarn
 			// If we had any pushes or pops, report them
 
 			if (pops > 0 && pushes > 0)
-				comment += string.Format("Pops {0}, Pushes {1}", pops, pushes);
+				comment += string.Format(CultureInfo.InvariantCulture, "Pops {0}, Pushes {1}", pops, pushes);
 			else if (pops > 0)
-				comment += string.Format("Pops {0}", pops);
+				comment += string.Format(CultureInfo.InvariantCulture, "Pops {0}", pops);
 			else if (pushes > 0)
-				comment += string.Format("Pushes {0}", pushes);
+				comment += string.Format(CultureInfo.InvariantCulture, "Pushes {0}", pushes);
 
 			// String lookup comments
 			switch (operation)
@@ -341,7 +342,7 @@ namespace Yarn
 					if ((string)operandA != null)
 					{
 						var text = p.GetString((string)operandA);
-						comment += string.Format("\"{0}\"", text);
+						comment += string.Format(CultureInfo.InvariantCulture, "\"{0}\"", text);
 					}
 
 					break;
@@ -353,7 +354,7 @@ namespace Yarn
 				comment = "; " + comment;
 			}
 
-			return string.Format("{0,-15} {1,-10} {2,-10} {3, -10}", operation.ToString(), opAString, opBString, comment);
+			return string.Format(CultureInfo.InvariantCulture, "{0,-15} {1,-10} {2,-10} {3, -10}", operation.ToString(), opAString, opBString, comment);
 		}
 	}
 

--- a/YarnSpinner/Value.cs
+++ b/YarnSpinner/Value.cs
@@ -1,5 +1,6 @@
 
 using System;
+using System.Globalization;
 
 namespace Yarn
 {
@@ -9,7 +10,9 @@ namespace Yarn
 
         public enum Type {
             Number,  // a constant number
+#pragma warning disable CA1720 // Identifier contains type name
             String,  // a string
+#pragma warning restore CA1720 // Identifier contains type name
             Bool,    // a boolean value
             Variable, // the name of a variable; will be expanded at runtime
             Null,    // the null value
@@ -32,7 +35,7 @@ namespace Yarn
                     case Type.Bool: return this.boolValue;
                 }
                 throw new InvalidOperationException(
-                    string.Format("Can't get good backing type for {0}", this.type)
+                    string.Format(CultureInfo.CurrentCulture, "Can't get good backing type for {0}", this.type)
                 );
             }
         }
@@ -44,7 +47,7 @@ namespace Yarn
                     return numberValue;
                 case Type.String:
                     try {
-                        return float.Parse (stringValue);
+                        return float.Parse (stringValue, CultureInfo.InvariantCulture);
                     }  catch (FormatException) {
                         return 0.0f;
                     }
@@ -82,11 +85,11 @@ namespace Yarn
                     if (float.IsNaN(numberValue) ) {
                         return "NaN";
                     }
-                    return numberValue.ToString ();
+                    return numberValue.ToString (CultureInfo.InvariantCulture);
                 case Type.String:
                     return stringValue;
                 case Type.Bool:
-                    return boolValue.ToString ();
+                    return boolValue.ToString (CultureInfo.InvariantCulture);
                 case Type.Null:
                     return "null";
                 default:
@@ -131,23 +134,23 @@ namespace Yarn
             }
             if (value.GetType() == typeof(string) ) {
                 type = Type.String;
-                stringValue = System.Convert.ToString(value);
+                stringValue = System.Convert.ToString(value, CultureInfo.InvariantCulture);
                 return;
             }
             if (value.GetType() == typeof(int) ||
                 value.GetType() == typeof(float) ||
                 value.GetType() == typeof(double)) {
                 type = Type.Number;
-                numberValue = System.Convert.ToSingle(value);
+                numberValue = System.Convert.ToSingle(value, CultureInfo.InvariantCulture);
 
                 return;
             }
             if (value.GetType() == typeof(bool) ) {
                 type = Type.Bool;
-                boolValue = System.Convert.ToBoolean(value);
+                boolValue = System.Convert.ToBoolean(value, CultureInfo.InvariantCulture);
                 return;
             }
-            var error = string.Format("Attempted to create a Value using a {0}; currently, " +
+            var error = string.Format(CultureInfo.CurrentCulture, "Attempted to create a Value using a {0}; currently, " +
                 "Values can only be numbers, strings, bools or null.", value.GetType().Name);
             throw new YarnException(error);
         }
@@ -175,7 +178,7 @@ namespace Yarn
                 case Type.Null:
                     return 0;
                 case Type.String:
-                    return this.stringValue.CompareTo (other.stringValue);
+                    return string.Compare(this.stringValue, other.stringValue, StringComparison.InvariantCulture);
                 case Type.Number:
                     return this.numberValue.CompareTo (other.numberValue);
                 case Type.Bool:
@@ -184,7 +187,7 @@ namespace Yarn
             }
 
             // try to do a string test at that point!
-            return this.AsString.CompareTo(other.AsString);
+            return string.Compare(this.AsString, other.AsString, StringComparison.InvariantCulture);
         }
 
         public override bool Equals (object obj)
@@ -225,7 +228,7 @@ namespace Yarn
 
         public override string ToString ()
         {
-            return string.Format ("[Value: type={0}, AsNumber={1}, AsBool={2}, AsString={3}]", type, AsNumber, AsBool, AsString);
+            return string.Format (CultureInfo.CurrentCulture, "[Value: type={0}, AsNumber={1}, AsBool={2}, AsString={3}]", type, AsNumber, AsBool, AsString);
         }
 
         public static Value operator+ (Value a, Value b) {
@@ -254,7 +257,7 @@ namespace Yarn
             }
 
             throw new System.ArgumentException(
-                string.Format("Cannot add types {0} and {1}.", a.type, b.type )
+                string.Format(CultureInfo.CurrentCulture, "Cannot add types {0} and {1}.", a.type, b.type )
             );
         }
 
@@ -266,7 +269,7 @@ namespace Yarn
             }
 
             throw new System.ArgumentException(
-                string.Format("Cannot subtract types {0} and {1}.", a.type, b.type )
+                string.Format(CultureInfo.CurrentCulture, "Cannot subtract types {0} and {1}.", a.type, b.type )
             );
         }
 
@@ -278,7 +281,7 @@ namespace Yarn
             }
 
             throw new System.ArgumentException(
-                string.Format("Cannot multiply types {0} and {1}.", a.type, b.type )
+                string.Format(CultureInfo.CurrentCulture, "Cannot multiply types {0} and {1}.", a.type, b.type )
             );
         }
 
@@ -290,7 +293,7 @@ namespace Yarn
             }
 
             throw new System.ArgumentException(
-                string.Format("Cannot divide types {0} and {1}.", a.type, b.type )
+                string.Format(CultureInfo.CurrentCulture, "Cannot divide types {0} and {1}.", a.type, b.type )
             );
         }
 
@@ -300,7 +303,7 @@ namespace Yarn
                 return new Value (a.AsNumber % b.AsNumber);
             }
             throw new System.ArgumentException(
-                string.Format("Cannot modulo types {0} and {1}.", a.type, b.type )
+                string.Format(CultureInfo.CurrentCulture, "Cannot modulo types {0} and {1}.", a.type, b.type )
             );
         }
 

--- a/YarnSpinner/VirtualMachine.cs
+++ b/YarnSpinner/VirtualMachine.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace Yarn
 {
@@ -222,14 +223,14 @@ namespace Yarn
                 /// - PushNumber
                 /** Pushes a number onto the stack.
                  */
-                state.PushValue (Convert.ToSingle(i.operandA));
+                state.PushValue (Convert.ToSingle(i.operandA, CultureInfo.InvariantCulture));
 
                 break;
             case ByteCode.PushBool:
                 /// - PushBool
                 /** Pushes a boolean value onto the stack.
                  */
-                state.PushValue (Convert.ToBoolean(i.operandA));
+                state.PushValue (Convert.ToBoolean(i.operandA, CultureInfo.InvariantCulture));
 
                 break;
             case ByteCode.PushNull:

--- a/YarnSpinner/YarnSpinner.csproj
+++ b/YarnSpinner/YarnSpinner.csproj
@@ -1,5 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\Microsoft.CodeAnalysis.FxCopAnalyzers.2.9.1\build\Microsoft.CodeAnalysis.FxCopAnalyzers.props" Condition="Exists('..\packages\Microsoft.CodeAnalysis.FxCopAnalyzers.2.9.1\build\Microsoft.CodeAnalysis.FxCopAnalyzers.props')" />
+  <Import Project="..\packages\Microsoft.NetFramework.Analyzers.2.9.1\build\Microsoft.NetFramework.Analyzers.props" Condition="Exists('..\packages\Microsoft.NetFramework.Analyzers.2.9.1\build\Microsoft.NetFramework.Analyzers.props')" />
+  <Import Project="..\packages\Microsoft.NetCore.Analyzers.2.9.1\build\Microsoft.NetCore.Analyzers.props" Condition="Exists('..\packages\Microsoft.NetCore.Analyzers.2.9.1\build\Microsoft.NetCore.Analyzers.props')" />
+  <Import Project="..\packages\Microsoft.CodeQuality.Analyzers.2.9.1\build\Microsoft.CodeQuality.Analyzers.props" Condition="Exists('..\packages\Microsoft.CodeQuality.Analyzers.2.9.1\build\Microsoft.CodeQuality.Analyzers.props')" />
+  <Import Project="..\packages\Microsoft.CodeAnalysis.VersionCheckAnalyzer.2.9.1\build\Microsoft.CodeAnalysis.VersionCheckAnalyzer.props" Condition="Exists('..\packages\Microsoft.CodeAnalysis.VersionCheckAnalyzer.2.9.1\build\Microsoft.CodeAnalysis.VersionCheckAnalyzer.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -11,6 +16,8 @@
     <AssemblyName>YarnSpinner</AssemblyName>
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <ReleaseVersion>0.9</ReleaseVersion>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>
@@ -30,6 +37,9 @@
         </Command>
       </CustomCommands>
     </CustomCommands>
+    <CodeAnalysisRuleSet>
+    </CodeAnalysisRuleSet>
+    <RunCodeAnalysis>false</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>none</DebugType>
@@ -47,6 +57,8 @@
         </Command>
       </CustomCommands>
     </CustomCommands>
+    <CodeAnalysisRuleSet>
+    </CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
@@ -62,6 +74,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Dialogue.cs" />
     <Compile Include="Lexer.cs" />
@@ -92,5 +105,25 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.VersionCheckAnalyzer.2.9.1\analyzers\dotnet\Microsoft.CodeAnalysis.VersionCheckAnalyzer.dll" />
+    <Analyzer Include="..\packages\Microsoft.CodeQuality.Analyzers.2.9.1\analyzers\dotnet\cs\Humanizer.dll" />
+    <Analyzer Include="..\packages\Microsoft.CodeQuality.Analyzers.2.9.1\analyzers\dotnet\cs\Microsoft.CodeQuality.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.CodeQuality.Analyzers.2.9.1\analyzers\dotnet\cs\Microsoft.CodeQuality.CSharp.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.NetCore.Analyzers.2.9.1\analyzers\dotnet\cs\Microsoft.NetCore.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.NetCore.Analyzers.2.9.1\analyzers\dotnet\cs\Microsoft.NetCore.CSharp.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.NetFramework.Analyzers.2.9.1\analyzers\dotnet\cs\Microsoft.NetFramework.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.NetFramework.Analyzers.2.9.1\analyzers\dotnet\cs\Microsoft.NetFramework.CSharp.Analyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>Dieses Projekt verweist auf mindestens ein NuGet-Paket, das auf diesem Computer fehlt. Verwenden Sie die Wiederherstellung von NuGet-Paketen, um die fehlenden Dateien herunterzuladen. Weitere Informationen finden Sie unter "http://go.microsoft.com/fwlink/?LinkID=322105". Die fehlende Datei ist "{0}".</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Microsoft.CodeAnalysis.VersionCheckAnalyzer.2.9.1\build\Microsoft.CodeAnalysis.VersionCheckAnalyzer.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeAnalysis.VersionCheckAnalyzer.2.9.1\build\Microsoft.CodeAnalysis.VersionCheckAnalyzer.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.CodeQuality.Analyzers.2.9.1\build\Microsoft.CodeQuality.Analyzers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeQuality.Analyzers.2.9.1\build\Microsoft.CodeQuality.Analyzers.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.NetCore.Analyzers.2.9.1\build\Microsoft.NetCore.Analyzers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.NetCore.Analyzers.2.9.1\build\Microsoft.NetCore.Analyzers.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.NetFramework.Analyzers.2.9.1\build\Microsoft.NetFramework.Analyzers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.NetFramework.Analyzers.2.9.1\build\Microsoft.NetFramework.Analyzers.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.CodeAnalysis.FxCopAnalyzers.2.9.1\build\Microsoft.CodeAnalysis.FxCopAnalyzers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeAnalysis.FxCopAnalyzers.2.9.1\build\Microsoft.CodeAnalysis.FxCopAnalyzers.props'))" />
+  </Target>
 </Project>

--- a/YarnSpinner/YarnSpinnerLexer.cs
+++ b/YarnSpinner/YarnSpinnerLexer.cs
@@ -61,7 +61,7 @@ public partial class YarnSpinnerLexer : Lexer {
     public const int Shortcuts = 6;
     public const int Command = 7;
     new public const int Action = 8;
-    public const int Option =9;
+    public const int Option = 9;
     public const int OptionLink = 10;
 
 	public static string[] channelNames = {

--- a/YarnSpinner/YarnSpinnerLexer.cs
+++ b/YarnSpinner/YarnSpinnerLexer.cs
@@ -52,9 +52,18 @@ public partial class YarnSpinnerLexer : Lexer {
 		LPAREN=64, RPAREN=65, COMMA=66, VAR_ID=67, BODY_NUMBER=68, FUNC_ID=69, 
 		COMMAND_UNKNOWN=70, ACTION=71, OPTION_SEPARATOR=72, OPTION_TEXT=73, OPTION_CLOSE=74, 
 		OPTION_LINK=75;
-	public const int
-		Title=1, Tags=2, HeaderText=3, Body=4, Text=5, Shortcuts=6, Command=7, 
-		Action=8, Option=9, OptionLink=10;
+
+    public const int Title = 1;
+    public const int Tags = 2;
+    public const int HeaderText = 3;
+    public const int Body = 4;
+    new public const int Text = 5;
+    public const int Shortcuts = 6;
+    public const int Command = 7;
+    new public const int Action = 8;
+    public const int Option =9;
+    public const int OptionLink = 10;
+
 	public static string[] channelNames = {
 		"DEFAULT_TOKEN_CHANNEL", "HIDDEN"
 	};

--- a/YarnSpinner/packages.config
+++ b/YarnSpinner/packages.config
@@ -1,5 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Antlr4.Runtime.Standard" version="4.7.1" targetFramework="net35" />
+  <package id="Microsoft.CodeAnalysis.FxCopAnalyzers" version="2.9.1" targetFramework="net35" />
+  <package id="Microsoft.CodeAnalysis.VersionCheckAnalyzer" version="2.9.1" targetFramework="net35" />
+  <package id="Microsoft.CodeQuality.Analyzers" version="2.9.1" targetFramework="net35" />
+  <package id="Microsoft.NetCore.Analyzers" version="2.9.1" targetFramework="net35" />
+  <package id="Microsoft.NetFramework.Analyzers" version="2.9.1" targetFramework="net35" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net35" />
 </packages>

--- a/YarnSpinnerConsole/FileFormatConverter.cs
+++ b/YarnSpinnerConsole/FileFormatConverter.cs
@@ -2,10 +2,11 @@
 using Newtonsoft.Json;
 using System.IO;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace Yarn
 {
-    public class FileFormatConverter
+    public static class FileFormatConverter
     {
         static internal int ConvertFormat(ConvertFormatOptions options)
         {
@@ -23,7 +24,7 @@ namespace Yarn
 
             var processName = System.IO.Path.GetFileName(Environment.GetCommandLineArgs()[0]);
 
-            YarnSpinnerConsole.Error(string.Format("You must specify a destination format. Run '{0} help convert' to learn more.", processName));
+            YarnSpinnerConsole.Error(string.Format(CultureInfo.CurrentCulture, "You must specify a destination format. Run '{0} help convert' to learn more.", processName));
             return 1;
         }
 
@@ -34,7 +35,7 @@ namespace Yarn
 
                 if (Loader.GetFormatFromFileName(file) == NodeFormat.JSON)
                 {
-                    YarnSpinnerConsole.Warn(string.Format("Not converting file {0}, because its name implies it's already in JSON format", file));
+                    YarnSpinnerConsole.Warn(string.Format(CultureInfo.CurrentCulture, "Not converting file {0}, because its name implies it's already in JSON format", file));
                     continue;
                 }
 
@@ -50,7 +51,7 @@ namespace Yarn
             {
                 if (Loader.GetFormatFromFileName(file) == NodeFormat.Text)
                 {
-                    YarnSpinnerConsole.Warn(string.Format("Not converting file {0}, because its name implies it's already in Yarn format", file));
+                    YarnSpinnerConsole.Warn(string.Format(CultureInfo.CurrentCulture, "Not converting file {0}, because its name implies it's already in Yarn format", file));
                     continue;
                 }
 
@@ -106,21 +107,21 @@ namespace Yarn
                     }
                     else if (propertyType.IsAssignableFrom(typeof(int)))
                     {
-                        value = ((int)property.GetValue(node, null)).ToString();
+                        value = ((int)property.GetValue(node, null)).ToString(CultureInfo.InvariantCulture);
                     }
                     else if (propertyType.IsAssignableFrom(typeof(Loader.NodeInfo.Position)))
                     {
                         var position = (Loader.NodeInfo.Position)property.GetValue(node, null);
 
-                        value = string.Format("{0},{1}", position.x, position.y);
+                        value = string.Format(CultureInfo.InvariantCulture, "{0},{1}", position.x, position.y);
                     } else {
-                        YarnSpinnerConsole.Error(string.Format("Internal error: Node {0}'s property {1} has unsupported type {2}", node.title, property.Name, propertyType.FullName));
+                        YarnSpinnerConsole.Error(string.Format(CultureInfo.CurrentCulture, "Internal error: Node {0}'s property {1} has unsupported type {2}", node.title, property.Name, propertyType.FullName));
 
                         // will never be run, but prevents the compiler being mean about us not returning a value
                         throw new Exception();
                     }
 
-                    var header = string.Format("{0}: {1}", field, value);
+                    var header = string.Format(CultureInfo.InvariantCulture, "{0}: {1}", field, value);
 
                     sb.AppendLine(header);
 

--- a/YarnSpinnerConsole/GlobalSuppressions.cs
+++ b/YarnSpinnerConsole/GlobalSuppressions.cs
@@ -1,0 +1,7 @@
+﻿
+// This file is used by Code Analysis to maintain SuppressMessage 
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given 
+// a specific target and scoped to a namespace, type, member, etc.
+
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2208:Instantiate argument exceptions correctly", Justification = "This SHOULD be fixed (to have more useful error messages), but it's out of scope for fixing locale issues.")]

--- a/YarnSpinnerConsole/LineAdder.cs
+++ b/YarnSpinnerConsole/LineAdder.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Yarn;
 using Newtonsoft.Json;
+using System.Globalization;
 
 namespace Yarn
 {
@@ -35,7 +36,7 @@ namespace Yarn
                     case NodeFormat.Text:
                         break;
                     default:
-                        YarnSpinnerConsole.Warn(string.Format("Skipping file {0}, which is in unsupported format '{1}'", file, fileFormat));
+                        YarnSpinnerConsole.Warn(string.Format(CultureInfo.CurrentCulture, "Skipping file {0}, which is in unsupported format '{1}'", file, fileFormat));
                         continue;
                 }
 
@@ -47,18 +48,20 @@ namespace Yarn
                     // First, we need to ensure that this file compiles.
                     d.LoadFile(file);
                 }
+#pragma warning disable CA1031 // Do not catch general exception types
                 catch
                 {
-                    YarnSpinnerConsole.Warn(string.Format("Skipping file {0} due to compilation errors.", file));
+                    YarnSpinnerConsole.Warn(string.Format(CultureInfo.CurrentCulture, "Skipping file {0} due to compilation errors.", file));
                     continue;
                 }
+#pragma warning restore CA1031 // Do not catch general exception types
 
                 Dictionary<string, LineInfo> linesWithNoTag = new Dictionary<string, LineInfo>();
 
                 // Filter the string info table to exclude lines that have a line code
                 foreach (var entry in d.GetStringInfoTable())
                 {
-                    if (entry.Key.StartsWith("line:") == false)
+                    if (entry.Key.StartsWith("line:", StringComparison.InvariantCulture) == false)
                     {
                         linesWithNoTag[entry.Key] = entry.Value;
                     }
@@ -66,7 +69,7 @@ namespace Yarn
 
                 if (linesWithNoTag.Count == 0)
                 {
-                    var message = string.Format("{0} had no untagged lines. Either they're all tagged already, or it has no localisable text.", file);
+                    var message = string.Format(CultureInfo.CurrentCulture, "{0} had no untagged lines. Either they're all tagged already, or it has no localisable text.", file);
                     YarnSpinnerConsole.Note(message);
                     continue;
                 }
@@ -143,11 +146,11 @@ namespace Yarn
 
                     if (options.verbose)
                     {
-                        YarnSpinnerConsole.Note(string.Format("Tagged line with ID \"{0}\" in node {1}: {2}", newTag, nodeInfo.title, existingLine));
+                        YarnSpinnerConsole.Note(string.Format(CultureInfo.CurrentCulture, "Tagged line with ID \"{0}\" in node {1}: {2}", newTag, nodeInfo.title, existingLine));
                     }
 
                     // Re-write the line.
-                    var newLine = string.Format("{0} #{1}", existingLine, newTag);
+                    var newLine = string.Format(CultureInfo.InvariantCulture, "{0} #{1}", existingLine, newTag);
                     lines[line.Value.lineNumber - 1] = newLine;
 
 
@@ -216,7 +219,7 @@ namespace Yarn
             bool isUnique = true;
             do
             {
-                tag = String.Format("line:{0:x6}", random.Next(0x1000000));
+                tag = string.Format(CultureInfo.InvariantCulture, "line:{0:x6}", random.Next(0x1000000));
 
                 isUnique = existingKeys.FindIndex(i => i == tag) == -1;
 

--- a/YarnSpinnerConsole/ProgramExporter.cs
+++ b/YarnSpinnerConsole/ProgramExporter.cs
@@ -1,14 +1,11 @@
 ﻿using System;
-
+using System.Globalization;
 using Newtonsoft.Json;
 
 namespace Yarn
 {
-    public class ProgramExporter
+    public static class ProgramExporter
     {
-        public ProgramExporter()
-        {
-        }
 
         internal static int Export(CompileOptions options)
         {
@@ -24,11 +21,13 @@ namespace Yarn
                     // First, we need to ensure that this file compiles.
                     dialogue.LoadFile(file);
                 }
+#pragma warning disable CA1031 // Do not catch general exception types
                 catch
                 {
-                    YarnSpinnerConsole.Warn(string.Format("Skipping file {0} due to compilation errors.", file));
+                    YarnSpinnerConsole.Warn(string.Format(CultureInfo.CurrentCulture, "Skipping file {0} due to compilation errors.", file));
                     continue;
                 }
+#pragma warning restore CA1031 // Do not catch general exception types
 
                 // Convert the program into BSON
                 var compiledProgram = dialogue.GetCompiledProgram(options.format);
@@ -37,9 +36,11 @@ namespace Yarn
 
                 try {
                     System.IO.File.WriteAllBytes(outputPath, compiledProgram);
+#pragma warning disable CA1031 // Do not catch general exception types
                 } catch (Exception e) {
-                    YarnSpinnerConsole.Error(string.Format("Error writing {0}: {1}", outputPath, e.Message));
+                    YarnSpinnerConsole.Error(string.Format(CultureInfo.CurrentCulture, "Error writing {0}: {1}", outputPath, e.Message));
                 }
+#pragma warning restore CA1031 // Do not catch general exception types
 
 
 

--- a/YarnSpinnerConsole/TableGenerator.cs
+++ b/YarnSpinnerConsole/TableGenerator.cs
@@ -1,11 +1,13 @@
 using System.Collections.Generic;
 using Yarn;
 using CsvHelper;
+using System.Globalization;
+using System;
 
 namespace Yarn
 {
 
-    class TableGenerator
+    static class TableGenerator
     {
         static internal int GenerateTables (GenerateTableOptions options)
         {
@@ -13,7 +15,7 @@ namespace Yarn
             YarnSpinnerConsole.CheckFileList(options.files, YarnSpinnerConsole.ALLOWED_EXTENSIONS);
 
             if (options.verbose && options.onlyUseTag != null) {
-                YarnSpinnerConsole.Note(string.Format("Only using lines from nodes tagged \"{0}\"", options.onlyUseTag));
+                YarnSpinnerConsole.Note(string.Format(CultureInfo.CurrentCulture, "Only using lines from nodes tagged \"{0}\"", options.onlyUseTag));
             }
 
             bool linesWereUntagged = false;
@@ -42,7 +44,7 @@ namespace Yarn
                         try {
                             stringInfo = dialogue.program.lineInfo[entry.Key];
                         } catch (KeyNotFoundException) {
-                            YarnSpinnerConsole.Error(string.Format("{0}: lineInfo table does not contain an entry for line {1} (\"{2}\")", file, entry.Key, entry.Value));
+                            YarnSpinnerConsole.Error(string.Format(CultureInfo.CurrentCulture, "{0}: lineInfo table does not contain an entry for line {1} (\"{2}\")", file, entry.Key, entry.Value));
                             return 1;
                         }
 
@@ -51,7 +53,7 @@ namespace Yarn
                         try {
                             node = dialogue.program.nodes[stringInfo.nodeName];
                         } catch (KeyNotFoundException) {
-                            YarnSpinnerConsole.Error(string.Format("{0}: Line {1}'s lineInfo claims that the line originates in node {2}, but this node is not present in this program.", file, entry.Key, stringInfo.nodeName));
+                            YarnSpinnerConsole.Error(string.Format(CultureInfo.CurrentCulture, "{0}: Line {1}'s lineInfo claims that the line originates in node {2}, but this node is not present in this program.", file, entry.Key, stringInfo.nodeName));
                             return 1;
                         }
 
@@ -66,7 +68,7 @@ namespace Yarn
 
                     }
 
-                    if (entry.Key.StartsWith("line:") == false) {
+                    if (entry.Key.StartsWith("line:", StringComparison.InvariantCulture) == false) {
                         anyLinesAreUntagged = true;
                     } else {
                         emittedStringTable [entry.Key] = entry.Value;
@@ -74,7 +76,7 @@ namespace Yarn
                 }
 
                 if (anyLinesAreUntagged) {
-                    YarnSpinnerConsole.Warn(string.Format("Untagged lines in {0}", file));
+                    YarnSpinnerConsole.Warn(string.Format(CultureInfo.CurrentCulture, "Untagged lines in {0}", file));
                     linesWereUntagged = true;
                 }
 
@@ -121,11 +123,11 @@ namespace Yarn
 
         }
 
-        string CreateCSVRow (params string[] entries) {
+        static string CreateCSVRow (params string[] entries) {
             return string.Join (",", entries);
         }
 
-        string CreateCSVRow (KeyValuePair<string,string> entry) {
+        static string CreateCSVRow (KeyValuePair<string,string> entry) {
             return CreateCSVRow (new string[] { entry.Key, entry.Value });
         }
     }

--- a/YarnSpinnerConsole/YarnSpinnerConsole.csproj
+++ b/YarnSpinnerConsole/YarnSpinnerConsole.csproj
@@ -1,4 +1,9 @@
 ﻿<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\Microsoft.CodeAnalysis.FxCopAnalyzers.2.9.1\build\Microsoft.CodeAnalysis.FxCopAnalyzers.props" Condition="Exists('..\packages\Microsoft.CodeAnalysis.FxCopAnalyzers.2.9.1\build\Microsoft.CodeAnalysis.FxCopAnalyzers.props')" />
+  <Import Project="..\packages\Microsoft.NetFramework.Analyzers.2.9.1\build\Microsoft.NetFramework.Analyzers.props" Condition="Exists('..\packages\Microsoft.NetFramework.Analyzers.2.9.1\build\Microsoft.NetFramework.Analyzers.props')" />
+  <Import Project="..\packages\Microsoft.NetCore.Analyzers.2.9.1\build\Microsoft.NetCore.Analyzers.props" Condition="Exists('..\packages\Microsoft.NetCore.Analyzers.2.9.1\build\Microsoft.NetCore.Analyzers.props')" />
+  <Import Project="..\packages\Microsoft.CodeQuality.Analyzers.2.9.1\build\Microsoft.CodeQuality.Analyzers.props" Condition="Exists('..\packages\Microsoft.CodeQuality.Analyzers.2.9.1\build\Microsoft.CodeQuality.Analyzers.props')" />
+  <Import Project="..\packages\Microsoft.CodeAnalysis.VersionCheckAnalyzer.2.9.1\build\Microsoft.CodeAnalysis.VersionCheckAnalyzer.props" Condition="Exists('..\packages\Microsoft.CodeAnalysis.VersionCheckAnalyzer.2.9.1\build\Microsoft.CodeAnalysis.VersionCheckAnalyzer.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
@@ -9,6 +14,8 @@
     <RootNamespace>Yarn</RootNamespace>
     <AssemblyName>YarnSpinnerConsole</AssemblyName>
     <ReleaseVersion>0.9</ReleaseVersion>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DebugSymbols>true</DebugSymbols>
@@ -22,6 +29,9 @@
     <Commandlineparameters>genstrings "../../../Tests/LocalisationTests/Simple Example Script.json" --verbose</Commandlineparameters>
     <ConsolePause>true</ConsolePause>
     <ExternalConsole>true</ExternalConsole>
+    <RunCodeAnalysis>false</RunCodeAnalysis>
+    <CodeAnalysisRuleSet>
+    </CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
     <Optimize>true</Optimize>
@@ -30,7 +40,7 @@
     <WarningLevel>4</WarningLevel>
     <Externalconsole>true</Externalconsole>
     <PlatformTarget>x86</PlatformTarget>
-    
+    <CodeAnalysisRuleSet />
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -47,6 +57,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Main.cs" />
     <Compile Include="LineAdder.cs" />
@@ -64,4 +75,24 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.VersionCheckAnalyzer.2.9.1\analyzers\dotnet\Microsoft.CodeAnalysis.VersionCheckAnalyzer.dll" />
+    <Analyzer Include="..\packages\Microsoft.CodeQuality.Analyzers.2.9.1\analyzers\dotnet\cs\Humanizer.dll" />
+    <Analyzer Include="..\packages\Microsoft.CodeQuality.Analyzers.2.9.1\analyzers\dotnet\cs\Microsoft.CodeQuality.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.CodeQuality.Analyzers.2.9.1\analyzers\dotnet\cs\Microsoft.CodeQuality.CSharp.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.NetCore.Analyzers.2.9.1\analyzers\dotnet\cs\Microsoft.NetCore.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.NetCore.Analyzers.2.9.1\analyzers\dotnet\cs\Microsoft.NetCore.CSharp.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.NetFramework.Analyzers.2.9.1\analyzers\dotnet\cs\Microsoft.NetFramework.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.NetFramework.Analyzers.2.9.1\analyzers\dotnet\cs\Microsoft.NetFramework.CSharp.Analyzers.dll" />
+  </ItemGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>Dieses Projekt verweist auf mindestens ein NuGet-Paket, das auf diesem Computer fehlt. Verwenden Sie die Wiederherstellung von NuGet-Paketen, um die fehlenden Dateien herunterzuladen. Weitere Informationen finden Sie unter "http://go.microsoft.com/fwlink/?LinkID=322105". Die fehlende Datei ist "{0}".</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Microsoft.CodeAnalysis.VersionCheckAnalyzer.2.9.1\build\Microsoft.CodeAnalysis.VersionCheckAnalyzer.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeAnalysis.VersionCheckAnalyzer.2.9.1\build\Microsoft.CodeAnalysis.VersionCheckAnalyzer.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.CodeQuality.Analyzers.2.9.1\build\Microsoft.CodeQuality.Analyzers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeQuality.Analyzers.2.9.1\build\Microsoft.CodeQuality.Analyzers.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.NetCore.Analyzers.2.9.1\build\Microsoft.NetCore.Analyzers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.NetCore.Analyzers.2.9.1\build\Microsoft.NetCore.Analyzers.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.NetFramework.Analyzers.2.9.1\build\Microsoft.NetFramework.Analyzers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.NetFramework.Analyzers.2.9.1\build\Microsoft.NetFramework.Analyzers.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.CodeAnalysis.FxCopAnalyzers.2.9.1\build\Microsoft.CodeAnalysis.FxCopAnalyzers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeAnalysis.FxCopAnalyzers.2.9.1\build\Microsoft.CodeAnalysis.FxCopAnalyzers.props'))" />
+  </Target>
 </Project>

--- a/YarnSpinnerConsole/packages.config
+++ b/YarnSpinnerConsole/packages.config
@@ -2,5 +2,10 @@
 <packages>
   <package id="CommandLineParser" version="2.0.275-beta" targetFramework="net40" />
   <package id="CsvHelper" version="2.16.0.0" targetFramework="net40" />
+  <package id="Microsoft.CodeAnalysis.FxCopAnalyzers" version="2.9.1" targetFramework="net40" />
+  <package id="Microsoft.CodeAnalysis.VersionCheckAnalyzer" version="2.9.1" targetFramework="net40" />
+  <package id="Microsoft.CodeQuality.Analyzers" version="2.9.1" targetFramework="net40" />
+  <package id="Microsoft.NetCore.Analyzers" version="2.9.1" targetFramework="net40" />
+  <package id="Microsoft.NetFramework.Analyzers" version="2.9.1" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net40" />
 </packages>

--- a/YarnSpinnerTests/GlobalSuppressions.cs
+++ b/YarnSpinnerTests/GlobalSuppressions.cs
@@ -1,0 +1,8 @@
+﻿
+// This file is used by Code Analysis to maintain SuppressMessage 
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given 
+// a specific target and scoped to a namespace, type, member, etc.
+
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1016:Mark assemblies with assembly version", Justification = "You don't really NEED this, I suppose.")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1051:Do not declare visible instance fields", Justification = "These normally would be properties.")]

--- a/YarnSpinnerTests/TestBase.cs
+++ b/YarnSpinnerTests/TestBase.cs
@@ -6,6 +6,7 @@ using Yarn;
 using System.Reflection;
 using System.IO;
 using System.Linq;
+using System.Globalization;
 
 namespace YarnSpinner.Tests
 {
@@ -39,9 +40,7 @@ namespace YarnSpinner.Tests
 
                 var testDataDirectory = path.Take(index).ToList();
 
-                var pathToTestData = string.Join(Path.DirectorySeparatorChar.ToString(), testDataDirectory.ToArray());
-
-                pathToTestData = Path.DirectorySeparatorChar + pathToTestData;
+                var pathToTestData = string.Join(Path.DirectorySeparatorChar.ToString(CultureInfo.InvariantCulture), testDataDirectory.ToArray());
 
                 return pathToTestData;
             }

--- a/YarnSpinnerTests/YarnSpinnerTests.csproj
+++ b/YarnSpinnerTests/YarnSpinnerTests.csproj
@@ -1,5 +1,10 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\Microsoft.CodeAnalysis.FxCopAnalyzers.2.9.1\build\Microsoft.CodeAnalysis.FxCopAnalyzers.props" Condition="Exists('..\packages\Microsoft.CodeAnalysis.FxCopAnalyzers.2.9.1\build\Microsoft.CodeAnalysis.FxCopAnalyzers.props')" />
+  <Import Project="..\packages\Microsoft.NetFramework.Analyzers.2.9.1\build\Microsoft.NetFramework.Analyzers.props" Condition="Exists('..\packages\Microsoft.NetFramework.Analyzers.2.9.1\build\Microsoft.NetFramework.Analyzers.props')" />
+  <Import Project="..\packages\Microsoft.NetCore.Analyzers.2.9.1\build\Microsoft.NetCore.Analyzers.props" Condition="Exists('..\packages\Microsoft.NetCore.Analyzers.2.9.1\build\Microsoft.NetCore.Analyzers.props')" />
+  <Import Project="..\packages\Microsoft.CodeQuality.Analyzers.2.9.1\build\Microsoft.CodeQuality.Analyzers.props" Condition="Exists('..\packages\Microsoft.CodeQuality.Analyzers.2.9.1\build\Microsoft.CodeQuality.Analyzers.props')" />
+  <Import Project="..\packages\Microsoft.CodeAnalysis.VersionCheckAnalyzer.2.9.1\build\Microsoft.CodeAnalysis.VersionCheckAnalyzer.props" Condition="Exists('..\packages\Microsoft.CodeAnalysis.VersionCheckAnalyzer.2.9.1\build\Microsoft.CodeAnalysis.VersionCheckAnalyzer.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -11,6 +16,8 @@
     <AssemblyName>YarnSpinnerTests</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <ReleaseVersion>0.9</ReleaseVersion>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -29,6 +36,9 @@
         </Command>
       </CustomCommands>
     </CustomCommands>
+    <RunCodeAnalysis>false</RunCodeAnalysis>
+    <CodeAnalysisRuleSet>
+    </CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>full</DebugType>
@@ -37,6 +47,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Externalconsole>true</Externalconsole>
+    <CodeAnalysisRuleSet />
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -45,6 +56,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="LanguageTests.cs" />
     <Compile Include="TestBase.cs" />
     <Compile Include="DialogueTests.cs" />
@@ -60,4 +72,24 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.VersionCheckAnalyzer.2.9.1\analyzers\dotnet\Microsoft.CodeAnalysis.VersionCheckAnalyzer.dll" />
+    <Analyzer Include="..\packages\Microsoft.CodeQuality.Analyzers.2.9.1\analyzers\dotnet\cs\Humanizer.dll" />
+    <Analyzer Include="..\packages\Microsoft.CodeQuality.Analyzers.2.9.1\analyzers\dotnet\cs\Microsoft.CodeQuality.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.CodeQuality.Analyzers.2.9.1\analyzers\dotnet\cs\Microsoft.CodeQuality.CSharp.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.NetCore.Analyzers.2.9.1\analyzers\dotnet\cs\Microsoft.NetCore.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.NetCore.Analyzers.2.9.1\analyzers\dotnet\cs\Microsoft.NetCore.CSharp.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.NetFramework.Analyzers.2.9.1\analyzers\dotnet\cs\Microsoft.NetFramework.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.NetFramework.Analyzers.2.9.1\analyzers\dotnet\cs\Microsoft.NetFramework.CSharp.Analyzers.dll" />
+  </ItemGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>Dieses Projekt verweist auf mindestens ein NuGet-Paket, das auf diesem Computer fehlt. Verwenden Sie die Wiederherstellung von NuGet-Paketen, um die fehlenden Dateien herunterzuladen. Weitere Informationen finden Sie unter "http://go.microsoft.com/fwlink/?LinkID=322105". Die fehlende Datei ist "{0}".</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Microsoft.CodeAnalysis.VersionCheckAnalyzer.2.9.1\build\Microsoft.CodeAnalysis.VersionCheckAnalyzer.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeAnalysis.VersionCheckAnalyzer.2.9.1\build\Microsoft.CodeAnalysis.VersionCheckAnalyzer.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.CodeQuality.Analyzers.2.9.1\build\Microsoft.CodeQuality.Analyzers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeQuality.Analyzers.2.9.1\build\Microsoft.CodeQuality.Analyzers.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.NetCore.Analyzers.2.9.1\build\Microsoft.NetCore.Analyzers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.NetCore.Analyzers.2.9.1\build\Microsoft.NetCore.Analyzers.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.NetFramework.Analyzers.2.9.1\build\Microsoft.NetFramework.Analyzers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.NetFramework.Analyzers.2.9.1\build\Microsoft.NetFramework.Analyzers.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.CodeAnalysis.FxCopAnalyzers.2.9.1\build\Microsoft.CodeAnalysis.FxCopAnalyzers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeAnalysis.FxCopAnalyzers.2.9.1\build\Microsoft.CodeAnalysis.FxCopAnalyzers.props'))" />
+  </Target>
 </Project>

--- a/YarnSpinnerTests/packages.config
+++ b/YarnSpinnerTests/packages.config
@@ -1,4 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.CodeAnalysis.FxCopAnalyzers" version="2.9.1" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.VersionCheckAnalyzer" version="2.9.1" targetFramework="net45" />
+  <package id="Microsoft.CodeQuality.Analyzers" version="2.9.1" targetFramework="net45" />
+  <package id="Microsoft.NetCore.Analyzers" version="2.9.1" targetFramework="net45" />
+  <package id="Microsoft.NetFramework.Analyzers" version="2.9.1" targetFramework="net45" />
   <package id="NUnit" version="3.6.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Fixes #154.

All program parsing and output should now use `InvariantCulture` or `StringComparison.Invariant`.

Currently, the output for logging etc. uses `CurrentCulture` instead of `InvariantCulture`.  
This is the same behaviour as before, but now explicit to mark those places as not processed. However, it may be better to set these to English or Invariant too, since the error messages aren't localised.

-----

I added the FxCop Analyzers to the project to find the locale problems, so warnings for certain issues should now show up when building with the Roslyn infrastructure. This happens with Visual Studio for example, but please check that I didn't break anything for your workflow.

I did some tiny fixes where suppressing the warning would have been more effort, but there are many warnings I just suppressed for now. I'll mark them in the commit via comment where appropriate, if that's supported here.